### PR TITLE
refactor: remove jQuery usage

### DIFF
--- a/script/common/dialog.js
+++ b/script/common/dialog.js
@@ -14,18 +14,20 @@ export async function prepareCommonRoll(rollData) {
                 icon: '<i class="fas fa-check"></i>',
                 label: game.i18n.localize("BUTTON.ROLL"),
                 callback: async html => {
+                    const element = html[0] ?? html;
                     if (rollData.flags?.isEvasion) {
-                        const skill = html.find("#selectedSkill")[0];
+                        const skill = element.querySelector("#selectedSkill");
                         if (skill) {
                             rollData.name = game.i18n.localize(skill.options[skill.selectedIndex].text);
                             rollData.evasions.selected = skill.value;
                         }
                     } else {
                         rollData.name = game.i18n.localize(rollData.name);
-                        rollData.target.base = parseInt(html.find("#target")[0].value, 10);
-                        rollData.rolledWith = html.find("[name=characteristic] :selected").text();
+                        rollData.target.base = parseInt(element.querySelector("#target").value, 10);
+                        const characteristic = element.querySelector("[name=characteristic]");
+                        rollData.rolledWith = characteristic.options[characteristic.selectedIndex].text;
                     }
-                    rollData.target.modifier = parseInt(html.find("#modifier")[0].value, 10);
+                    rollData.target.modifier = parseInt(element.querySelector("#modifier").value, 10);
                     rollData.flags.isDamageRoll = false;
                     rollData.flags.isCombatRoll = false;
                     await commonRoll(rollData);
@@ -41,10 +43,11 @@ export async function prepareCommonRoll(rollData) {
         default: "roll",
         close: () => {},
         render: html => {
-            const sel = html.find("select[name=characteristic");
-            const target = html.find("#target");
-            sel.change(() => {
-                target.val(sel.val());
+            const element = html[0] ?? html;
+            const sel = element.querySelector("select[name=characteristic]");
+            const target = element.querySelector("#target");
+            sel?.addEventListener("change", () => {
+                target.value = sel.value;
             });
         }
     }, {
@@ -71,23 +74,24 @@ export async function prepareCombatRoll(rollData, actorRef) {
                     icon: '<i class="fas fa-check"></i>',
                     label: game.i18n.localize("BUTTON.ROLL"),
                     callback: async html => {
+                        const element = html[0] ?? html;
                         rollData.name = game.i18n.localize(rollData.name);
-                        rollData.target.base = parseInt(html.find("#target")[0]?.value, 10);
-                        rollData.target.modifier = parseInt(html.find("#modifier")[0]?.value, 10);
-                        const range = html.find("#range")[0];
+                        rollData.target.base = parseInt(element.querySelector("#target")?.value, 10);
+                        rollData.target.modifier = parseInt(element.querySelector("#modifier")?.value, 10);
+                        const range = element.querySelector("#range");
                         if (range) {
                             rollData.rangeMod = parseInt(range.value, 10);
                             rollData.rangeModText = range.options[range.selectedIndex].text;
                         }
 
-                        const attackType = html.find("#attackType")[0];
+                        const attackType = element.querySelector("#attackType");
                         rollData.attackType = {
                             name: attackType?.value,
                             text: attackType?.options[attackType.selectedIndex].text,
                             modifier: 0
                         };
 
-                        const aim = html.find("#aim")[0];
+                        const aim = element.querySelector("#aim");
                         rollData.aim = {
                             val: parseInt(aim?.value, 10),
                             isAiming: aim?.value !== "0",
@@ -95,15 +99,15 @@ export async function prepareCombatRoll(rollData, actorRef) {
                         };
 
                         if (rollData.weapon.traits.inaccurate) {
-                            rollData.aim.val=0;
+                            rollData.aim.val = 0;
                         } else if (rollData.weapon.traits.accurate && rollData.aim.isAiming) {
                             rollData.aim.val += 10;
                         }
 
-                        rollData.weapon.damageFormula = html.find("#damageFormula")[0].value.replace(" ", "");
-                        rollData.weapon.damageType = html.find("#damageType")[0].value;
-                        rollData.weapon.damageBonus = parseInt(html.find("#damageBonus")[0].value, 10);
-                        rollData.weapon.penetrationFormula = html.find("#penetration")[0].value;
+                        rollData.weapon.damageFormula = element.querySelector("#damageFormula").value.replace(" ", "");
+                        rollData.weapon.damageType = element.querySelector("#damageType").value;
+                        rollData.weapon.damageBonus = parseInt(element.querySelector("#damageBonus").value, 10);
+                        rollData.weapon.penetrationFormula = element.querySelector("#penetration").value;
                         rollData.flags.isDamageRoll = false;
                         rollData.flags.isCombatRoll = true;
 
@@ -141,17 +145,18 @@ export async function preparePsychicPowerRoll(rollData) {
                 icon: '<i class="fas fa-check"></i>',
                 label: game.i18n.localize("BUTTON.ROLL"),
                 callback: async html => {
+                    const element = html[0] ?? html;
                     rollData.name = game.i18n.localize(rollData.name);
-                    rollData.target.base = parseInt(html.find("#target")[0]?.value, 10);
-                    rollData.target.modifier = parseInt(html.find("#modifier")[0]?.value, 10);
-                    rollData.psy.value = parseInt(html.find("#psy")[0].value, 10);
-                    rollData.psy.warpConduit = html.find("#warpConduit")[0].checked;
-                    rollData.weapon.damageFormula = html.find("#damageFormula")[0].value;
-                    rollData.weapon.damageType = html.find("#damageType")[0].value;
-                    rollData.weapon.damageBonus = parseInt(html.find("#damageBonus")[0].value, 10);
-                    rollData.weapon.penetrationFormula = html.find("#penetration")[0].value;
+                    rollData.target.base = parseInt(element.querySelector("#target")?.value, 10);
+                    rollData.target.modifier = parseInt(element.querySelector("#modifier")?.value, 10);
+                    rollData.psy.value = parseInt(element.querySelector("#psy").value, 10);
+                    rollData.psy.warpConduit = element.querySelector("#warpConduit").checked;
+                    rollData.weapon.damageFormula = element.querySelector("#damageFormula").value;
+                    rollData.weapon.damageType = element.querySelector("#damageType").value;
+                    rollData.weapon.damageBonus = parseInt(element.querySelector("#damageBonus").value, 10);
+                    rollData.weapon.penetrationFormula = element.querySelector("#penetration").value;
                     rollData.weapon.rateOfFire = { burst: rollData.psy.value, full: rollData.psy.value };
-                    const attackType = html.find("#attackType")[0];
+                    const attackType = element.querySelector("#attackType");
                     rollData.attackType.name = attackType.value;
                     rollData.attackType.text = attackType.options[attackType.selectedIndex].text;
                     rollData.psy.useModifier = true;

--- a/script/dark-heresy.js
+++ b/script/dark-heresy.js
@@ -115,7 +115,7 @@ Hooks.once("ready", function() {
 
 /** Add Event Listeners for Buttons on chat boxes */
 Hooks.once("renderChatLog", (chat, html) => {
-    chatListeners(html);
+    chatListeners(html[0]);
 });
 
 /** Add Options to context Menu of chatmessages */
@@ -134,6 +134,11 @@ Hooks.on("hotbarDrop", (bar, data, slot) => {
 });
 
 Hooks.on("renderDarkHeresySheet", (sheet, html, data) => {
-    html.find("input.cost").prop("disabled", game.settings.get("dark-heresy", "autoCalcXPCosts"));
-    html.find(":not(.psychic-power) > input.item-cost").prop("disabled", game.settings.get("dark-heresy", "autoCalcXPCosts"));
+    const element = html[0] ?? html;
+    element.querySelectorAll("input.cost").forEach(input => {
+        input.disabled = game.settings.get("dark-heresy", "autoCalcXPCosts");
+    });
+    element.querySelectorAll(":not(.psychic-power) > input.item-cost").forEach(input => {
+        input.disabled = game.settings.get("dark-heresy", "autoCalcXPCosts");
+    });
 });

--- a/script/sheet/actor/acolyte.js
+++ b/script/sheet/actor/acolyte.js
@@ -34,10 +34,11 @@ export class AcolyteSheet extends DarkHeresySheet {
 
     activateListeners(html) {
         super.activateListeners(html);
-        html.find(".aptitude-create").click(async ev => { await this._onAptitudeCreate(ev); });
-        html.find(".aptitude-delete").click(async ev => { await this._onAptitudeDelete(ev); });
-        html.find(".item-cost").focusout(async ev => { await this._onItemCostFocusOut(ev); });
-        html.find(".item-starter").click(async ev => { await this._onItemStarterClick(ev); });
+        const element = html[0] ?? html;
+        element.querySelectorAll(".aptitude-create").forEach(el => el.addEventListener("click", async ev => { await this._onAptitudeCreate(ev); }));
+        element.querySelectorAll(".aptitude-delete").forEach(el => el.addEventListener("click", async ev => { await this._onAptitudeDelete(ev); }));
+        element.querySelectorAll(".item-cost").forEach(el => el.addEventListener("focusout", async ev => { await this._onItemCostFocusOut(ev); }));
+        element.querySelectorAll(".item-starter").forEach(el => el.addEventListener("click", async ev => { await this._onItemStarterClick(ev); }));
     }
 
     async _onAptitudeCreate(event) {
@@ -50,23 +51,23 @@ export class AcolyteSheet extends DarkHeresySheet {
 
     async _onAptitudeDelete(event) {
         event.preventDefault();
-        const div = $(event.currentTarget).parents(".item");
-        const aptitudeId = div.data("aptitudeId").toString();
+        const div = event.currentTarget.closest(".item");
+        const aptitudeId = div.dataset.aptitudeId.toString();
         await this.actor.update({[`system.aptitudes.-=${aptitudeId}`]: null});
         this._render(true);
     }
 
     async _onItemCostFocusOut(event) {
         event.preventDefault();
-        const div = $(event.currentTarget).parents(".item");
-        let item = this.actor.items.get(div.data("itemId"));
-        item.update({"system.cost": $(event.currentTarget)[0].value});
+        const div = event.currentTarget.closest(".item");
+        let item = this.actor.items.get(div.dataset.itemId);
+        item.update({"system.cost": event.currentTarget.value});
     }
 
     async _onItemStarterClick(event) {
         event.preventDefault();
-        const div = $(event.currentTarget).parents(".item");
-        let item = this.actor.items.get(div.data("itemId"));
-        item.update({"system.starter": $(event.currentTarget)[0].checked});
+        const div = event.currentTarget.closest(".item");
+        let item = this.actor.items.get(div.dataset.itemId);
+        item.update({"system.starter": event.currentTarget.checked});
     }
 }

--- a/script/sheet/actor/actor.js
+++ b/script/sheet/actor/actor.js
@@ -4,17 +4,18 @@ import DarkHeresyUtil from "../../common/util.js";
 export class DarkHeresySheet extends ActorSheet {
     activateListeners(html) {
         super.activateListeners(html);
-        html.find(".item-create").click(ev => this._onItemCreate(ev));
-        html.find(".item-edit").click(ev => this._onItemEdit(ev));
-        html.find(".item-delete").click(ev => this._onItemDelete(ev));
-        html.find("input").focusin(ev => this._onFocusIn(ev));
-        html.find(".roll-characteristic").click(async ev => await this._prepareRollCharacteristic(ev));
-        html.find(".roll-skill").click(async ev => await this._prepareRollSkill(ev));
-        html.find(".roll-speciality").click(async ev => await this._prepareRollSpeciality(ev));
-        html.find(".roll-insanity").click(async ev => await this._prepareRollInsanity(ev));
-        html.find(".roll-corruption").click(async ev => await this._prepareRollCorruption(ev));
-        html.find(".roll-weapon").click(async ev => await this._prepareRollWeapon(ev));
-        html.find(".roll-psychic-power").click(async ev => await this._prepareRollPsychicPower(ev));
+        const element = html[0] ?? html;
+        element.querySelectorAll(".item-create").forEach(el => el.addEventListener("click", ev => this._onItemCreate(ev)));
+        element.querySelectorAll(".item-edit").forEach(el => el.addEventListener("click", ev => this._onItemEdit(ev)));
+        element.querySelectorAll(".item-delete").forEach(el => el.addEventListener("click", ev => this._onItemDelete(ev)));
+        element.querySelectorAll("input").forEach(el => el.addEventListener("focusin", ev => this._onFocusIn(ev)));
+        element.querySelectorAll(".roll-characteristic").forEach(el => el.addEventListener("click", async ev => await this._prepareRollCharacteristic(ev)));
+        element.querySelectorAll(".roll-skill").forEach(el => el.addEventListener("click", async ev => await this._prepareRollSkill(ev)));
+        element.querySelectorAll(".roll-speciality").forEach(el => el.addEventListener("click", async ev => await this._prepareRollSpeciality(ev)));
+        element.querySelectorAll(".roll-insanity").forEach(el => el.addEventListener("click", async ev => await this._prepareRollInsanity(ev)));
+        element.querySelectorAll(".roll-corruption").forEach(el => el.addEventListener("click", async ev => await this._prepareRollCorruption(ev)));
+        element.querySelectorAll(".roll-weapon").forEach(el => el.addEventListener("click", async ev => await this._prepareRollWeapon(ev)));
+        element.querySelectorAll(".roll-psychic-power").forEach(el => el.addEventListener("click", async ev => await this._prepareRollPsychicPower(ev)));
     }
 
     /** @override */
@@ -73,16 +74,17 @@ export class DarkHeresySheet extends ActorSheet {
 
     _onItemEdit(event) {
         event.preventDefault();
-        const div = $(event.currentTarget).parents(".item");
-        let item = this.actor.items.get(div.data("itemId"));
+        const div = event.currentTarget.closest(".item");
+        let item = this.actor.items.get(div.dataset.itemId);
         item.sheet.render(true);
     }
 
     _onItemDelete(event) {
         event.preventDefault();
-        const div = $(event.currentTarget).parents(".item");
-        this.actor.deleteEmbeddedDocuments("Item", [div.data("itemId")]);
-        div.slideUp(200, () => this.render(false));
+        const div = event.currentTarget.closest(".item");
+        this.actor.deleteEmbeddedDocuments("Item", [div.dataset.itemId]);
+        div.remove();
+        this.render(false);
     }
 
     async _prepareCustomRoll() {
@@ -97,7 +99,7 @@ export class DarkHeresySheet extends ActorSheet {
 
     async _prepareRollCharacteristic(event) {
         event.preventDefault();
-        const characteristicName = $(event.currentTarget).data("characteristic");
+        const characteristicName = event.currentTarget.dataset.characteristic;
         await prepareCommonRoll(
             DarkHeresyUtil.createCharacteristicRollData(this.actor, characteristicName)
         );
@@ -105,7 +107,7 @@ export class DarkHeresySheet extends ActorSheet {
 
     async _prepareRollSkill(event) {
         event.preventDefault();
-        const skillName = $(event.currentTarget).data("skill");
+        const skillName = event.currentTarget.dataset.skill;
         await prepareCommonRoll(
             DarkHeresyUtil.createSkillRollData(this.actor, skillName)
         );
@@ -113,8 +115,8 @@ export class DarkHeresySheet extends ActorSheet {
 
     async _prepareRollSpeciality(event) {
         event.preventDefault();
-        const skillName = $(event.currentTarget).parents(".item").data("skill");
-        const specialityName = $(event.currentTarget).data("speciality");
+        const skillName = event.currentTarget.closest(".item").dataset.skill;
+        const specialityName = event.currentTarget.dataset.speciality;
         await prepareCommonRoll(
             DarkHeresyUtil.createSpecialtyRollData(this.actor, skillName, specialityName)
         );
@@ -136,8 +138,8 @@ export class DarkHeresySheet extends ActorSheet {
 
     async _prepareRollWeapon(event) {
         event.preventDefault();
-        const div = $(event.currentTarget).parents(".item");
-        const weapon = this.actor.items.get(div.data("itemId"));
+        const div = event.currentTarget.closest(".item");
+        const weapon = this.actor.items.get(div.dataset.itemId);
         await prepareCombatRoll(
             DarkHeresyUtil.createWeaponRollData(this.actor, weapon),
             this.actor
@@ -146,11 +148,15 @@ export class DarkHeresySheet extends ActorSheet {
 
     async _prepareRollPsychicPower(event) {
         event.preventDefault();
-        const div = $(event.currentTarget).parents(".item");
-        const psychicPower = this.actor.items.get(div.data("itemId"));
+        const div = event.currentTarget.closest(".item");
+        const psychicPower = this.actor.items.get(div.dataset.itemId);
         await preparePsychicPowerRoll(
             DarkHeresyUtil.createPsychicRollData(this.actor, psychicPower)
         );
+    }
+
+    _onFocusIn(event) {
+        event.currentTarget.select();
     }
 
     constructItemLists() {

--- a/script/sheet/actor/npc.js
+++ b/script/sheet/actor/npc.js
@@ -34,21 +34,22 @@ export class NpcSheet extends DarkHeresySheet {
 
     activateListeners(html) {
         super.activateListeners(html);
-        html.find(".item-cost").focusout(async ev => { await this._onItemCostFocusOut(ev); });
-        html.find(".item-starter").click(async ev => { await this._onItemStarterClick(ev); });
+        const element = html[0] ?? html;
+        element.querySelectorAll(".item-cost").forEach(el => el.addEventListener("focusout", async ev => { await this._onItemCostFocusOut(ev); }));
+        element.querySelectorAll(".item-starter").forEach(el => el.addEventListener("click", async ev => { await this._onItemStarterClick(ev); }));
     }
 
     async _onItemCostFocusOut(event) {
         event.preventDefault();
-        const div = $(event.currentTarget).parents(".item");
-        let item = this.actor.items.get(div.data("itemId"));
-        item.update({"system.cost": $(event.currentTarget)[0].value});
+        const div = event.currentTarget.closest(".item");
+        let item = this.actor.items.get(div.dataset.itemId);
+        item.update({"system.cost": event.currentTarget.value});
     }
 
     async _onItemStarterClick(event) {
         event.preventDefault();
-        const div = $(event.currentTarget).parents(".item");
-        let item = this.actor.items.get(div.data("itemId"));
-        item.update({"system.starter": $(event.currentTarget)[0].checked});
+        const div = event.currentTarget.closest(".item");
+        let item = this.actor.items.get(div.dataset.itemId);
+        item.update({"system.starter": event.currentTarget.checked});
     }
 }

--- a/script/sheet/item.js
+++ b/script/sheet/item.js
@@ -1,7 +1,10 @@
 export class DarkHeresyItemSheet extends ItemSheet {
     activateListeners(html) {
         super.activateListeners(html);
-        html.find("input").focusin(ev => this._onFocusIn(ev));
+        const element = html[0] ?? html;
+        element.querySelectorAll("input").forEach(i => {
+            i.addEventListener("focusin", ev => this._onFocusIn(ev));
+        });
     }
 
     async getData() {
@@ -32,6 +35,6 @@ export class DarkHeresyItemSheet extends ItemSheet {
     }
 
     _onFocusIn(event) {
-        $(event.currentTarget).select();
+        event.currentTarget.select();
     }
 }

--- a/template/dialog/combat-roll.hbs
+++ b/template/dialog/combat-roll.hbs
@@ -73,7 +73,7 @@
     </div>
 </div>
 <script>
-    $(".wrapper input").focusin(function () {
-        $(this).select();
+    document.querySelectorAll(".wrapper input").forEach(el => {
+        el.addEventListener("focusin", () => el.select());
     });
 </script>

--- a/template/dialog/common-roll.hbs
+++ b/template/dialog/common-roll.hbs
@@ -32,7 +32,7 @@
     </div>
 </div>
 <script>
-    $(".wrapper input").focusin(function () {
-        $(this).select();
+    document.querySelectorAll(".wrapper input").forEach(el => {
+        el.addEventListener("focusin", () => el.select());
     });
 </script>

--- a/template/dialog/psychic-power-roll.hbs
+++ b/template/dialog/psychic-power-roll.hbs
@@ -54,7 +54,7 @@
     </div>
 </div>
 <script>
-    $(".wrapper input").focusin(function () {
-        $(this).select();
+    document.querySelectorAll(".wrapper input").forEach(el => {
+        el.addEventListener("focusin", () => el.select());
     });
 </script>


### PR DESCRIPTION
## Summary
- drop jQuery from chat roll interactions
- refactor item and actor sheets to use native DOM
- replace dialog scripts with vanilla JavaScript

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68bfe51f6de083269ff6bf26e64ce8f6