### PR TITLE
Remove penetration note from damage chat

### DIFF
--- a/script/common/roll.js
+++ b/script/common/roll.js
@@ -725,16 +725,6 @@ export async function sendDamageToChat(rollData) {
         rollData.tokenId = speaker.token;
     }
 
-    // Note penetration versus the first controlled token's armour if available
-    const target = canvas.tokens.controlled[0]?.actor;
-    if (target) {
-        rollData.damages.forEach(d => {
-            const armour = target._getArmour(d.location);
-            const remaining = Math.max(armour - d.penetration, 0);
-            d.penNote = `${armour} → ${remaining}`;
-        });
-    }
-
     chatData.rolls = rollData.damages.flatMap(r => r.damageRoll);
 
     const html = await renderTemplate("systems/dark-heresy/template/chat/damage.hbs", rollData);

--- a/template/chat/damage.hbs
+++ b/template/chat/damage.hbs
@@ -16,7 +16,7 @@
             <div>
                 <p><strong>{{localize "CHAT.DAMAGE"}}:</strong> <span class="damage-total">{{damage.total}}</span> <strong class="damage-type">{{damageTypeShort ../weapon.damageType}}</strong></p>
             </div>
-            <p><strong>{{localize "CHAT.PENETRATION"}}:</strong> <span class="damage-penetration">{{penetration}}</span>{{#if penNote}} <span class="pen-note">({{penNote}})</span>{{/if}}</p>
+            <p><strong>{{localize "CHAT.PENETRATION"}}:</strong> <span class="damage-penetration">{{penetration}}</span></p>
             {{#if damage.righteousFury}}
             <p><strong>{{localize "CHAT.RIGHTEOUS_FURY"}}:</strong> <span class="damage-righteous-fury">{{damage.righteousFury}}</span></p>
             {{/if}}


### PR DESCRIPTION

- stop looking up targeted token armour when sending damage rolls to chat
- remove penetration note output from damage template
