### PR TITLE
Support insanity and corruption bonuses in formulas

### DIFF
--- a/script/common/actor.js
+++ b/script/common/actor.js
@@ -540,6 +540,8 @@ export class DarkHeresyActor extends Actor {
         for (let characteristic of Object.values(this.characteristics)) {
             boni.push({ regex: new RegExp(`${characteristic.short}B`, "gi"), value: characteristic.bonus });
         }
+        boni.push({ regex: /IB/gi, value: this.system.insanityBonus });
+        boni.push({ regex: /CB/gi, value: this.system.corruptionBonus });
         return boni;
     }
 


### PR DESCRIPTION

- expose insanity and corruption bonuses via `IB` and `CB` regex matches

