### PR TITLE
Add blast template placement with scatter

### DIFF
--- a/script/common/placeable-template.js
+++ b/script/common/placeable-template.js
@@ -56,6 +56,32 @@ export class PlaceableTemplate extends MeasuredTemplate {
     /* -------------------------------------------- */
 
     /**
+     * A factory method to create a circle PlaceableTemplate instance
+     * @param {string} origin  The id of the item originating the blast.
+     * @param {number} radius  The radius of the blast.
+     * @returns {PlaceableTemplate}    The template.
+     */
+    static circle(origin, radius) {
+        const templateData = {
+            t: "circle",
+            user: game.user.id,
+            distance: radius,
+            direction: 0,
+            x: 0,
+            y: 0,
+            fillColor: game.user.color,
+            flags: { "dark-heresy": { origin: origin } }
+        };
+        const cls = CONFIG.MeasuredTemplate.documentClass;
+        const template = new cls(templateData, {parent: canvas.scene});
+        const object = new this(template);
+        object.actorSheet = game.actors.get(origin.actor).sheet || null;
+        return object;
+    }
+
+    /* -------------------------------------------- */
+
+    /**
      * Creates a preview of the ability template.
      * @returns {Promise}  A promise that resolves with the final measured template if created.
      */

--- a/script/common/roll.js
+++ b/script/common/roll.js
@@ -23,6 +23,12 @@ export async function commonRoll(rollData) {
  * @param {object} rollData
  */
 export async function combatRoll(rollData) {
+    let blastTemplate;
+    if (rollData.weapon.traits.blast && game.settings.get("dark-heresy", "useBlasttemplate")) {
+        const template = PlaceableTemplate.circle({ item: rollData.itemId, actor: rollData.ownerId },
+            rollData.weapon.traits.blast);
+        [blastTemplate] = await template.drawPreview();
+    }
     if (rollData.weapon.traits.spray && game.settings.get("dark-heresy", "useSpraytemplate")) {
         let template = PlaceableTemplate.cone({ item: rollData.itemId, actor: rollData.ownerId },
             30, rollData.weapon.range);
@@ -37,6 +43,9 @@ export async function combatRoll(rollData) {
     } else {
         await _computeCombatTarget(rollData);
         await _rollTarget(rollData);
+        if (blastTemplate && !rollData.flags.isSuccess) {
+            await _scatterTemplate(blastTemplate, rollData.dof, rollData.ownerId);
+        }
         rollData.attackDos = rollData.dos;
         rollData.attackResult = rollData.result;
         if (!rollData.isReRoll) {
@@ -157,6 +166,38 @@ async function _rollTarget(rollData) {
         rollData.dof = 1 + _getDegree(rollData.result, rollData.target.final);
     }
     if (rollData.psy) _computePsychicPhenomena(rollData);
+}
+
+/**
+ * Scatter a template in a random direction by a number of meters.
+ * @param {MeasuredTemplateDocument} templateDoc
+ * @param {number} meters
+ * @param {string} actorId
+ */
+async function _scatterTemplate(templateDoc, meters, actorId) {
+    const dirRoll = new Roll("1d8");
+    await dirRoll.evaluate({ async: false });
+    const directions = {
+        1: {dx: 0, dy: -1},
+        2: {dx: 1, dy: -1},
+        3: {dx: 1, dy: 0},
+        4: {dx: 1, dy: 1},
+        5: {dx: 0, dy: 1},
+        6: {dx: -1, dy: 1},
+        7: {dx: -1, dy: 0},
+        8: {dx: -1, dy: -1}
+    };
+    const {dx, dy} = directions[dirRoll.total];
+    const distance = meters * canvas.grid.size;
+    await templateDoc.update({
+        x: templateDoc.x + dx * distance,
+        y: templateDoc.y + dy * distance
+    });
+    const speaker = ChatMessage.getSpeaker({actor: game.actors.get(actorId)});
+    ChatMessage.create({
+        content: `Scatter ${meters}m (direction ${dirRoll.total})`,
+        speaker
+    });
 }
 /**
  * Handle rolling and collecting parts of a combat damage roll.

--- a/script/common/util.js
+++ b/script/common/util.js
@@ -169,7 +169,8 @@ export default class DarkHeresyUtil {
             storm: this.hasNamedTrait(/Storm/gi, traits),
             twinLinked: this.hasNamedTrait(/Twin.?-? *Linked/gi, traits),
             force: this.hasNamedTrait(/Force/gi, traits),
-            inaccurate: this.hasNamedTrait(/Inaccurate/gi, traits)
+            inaccurate: this.hasNamedTrait(/Inaccurate/gi, traits),
+            blast: this.extractNumberedTrait(/Blast.*\(\d+\)/gi, traits)
         };
     }
 

--- a/script/dark-heresy.js
+++ b/script/dark-heresy.js
@@ -97,6 +97,14 @@ Hooks.once("init", function() {
         default: true,
         type: Boolean
     });
+    game.settings.register("dark-heresy", "useBlasttemplate", {
+        name: "Use Template with Blast Weapons",
+        hint: "If enabled, Blast Weapons will require the user to put down a template before the roll is made. Templates are NOT removed automatically",
+        scope: "client",
+        config: true,
+        default: true,
+        type: Boolean
+    });
 
 });
 


### PR DESCRIPTION
## Summary
- support Blast traits by parsing `Blast(X)`
- allow placing circular templates for blast weapons and scatter on missed attacks
- add setting to toggle blast templates

## Testing
- `npm test` *(fails: npm: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68c5c1472f3c8326a3997af97ac096f9