### PR TITLE
Auto-select ranged modifiers based on targeted distance

### DIFF
--- a/less/dialog/dialog.less
+++ b/less/dialog/dialog.less
@@ -32,6 +32,10 @@
     font-size: 16px;
 }
 
+.dark-heresy.dialog .wrapper select.auto-range-selected {
+    color: var(--color-text-hyperlink);
+}
+
 .dark-heresy.dialog .wrapper .range {
     width: 66px
 }

--- a/script/common/dialog.js
+++ b/script/common/dialog.js
@@ -61,9 +61,22 @@ export async function prepareCommonRoll(rollData) {
  * @param {DarkHeresyActor} actorRef
  */
 export async function prepareCombatRoll(rollData, actorRef) {
-    if (rollData.weapon.isRanged && rollData.weapon.clip.value <= 0) {
+    if (rollData.weapon.isRange && rollData.weapon.clip.value <= 0) {
         reportEmptyClip(rollData);
     } else {
+        rollData.flags = rollData.flags ?? {};
+        if (rollData.weapon.isRange) {
+            const autoRangeSelection = _determineAutomaticRange(rollData, actorRef);
+            if (autoRangeSelection) {
+                rollData.rangeMod = autoRangeSelection.modifier;
+                rollData.flags.autoSelectedRange = true;
+            } else {
+                rollData.rangeMod = 0;
+                rollData.flags.autoSelectedRange = false;
+            }
+        } else {
+            rollData.flags.autoSelectedRange = false;
+        }
         const html = await renderTemplate("systems/dark-heresy/template/dialog/combat-roll.hbs", rollData);
         let dialog = new Dialog({
             title: rollData.name,
@@ -127,6 +140,107 @@ export async function prepareCombatRoll(rollData, actorRef) {
         }, {width: 200});
         dialog.render(true);
     }
+}
+
+function _determineAutomaticRange(rollData, actorRef) {
+    if (!rollData.weapon?.isRange || !actorRef) return null;
+    if (!game?.user) return null;
+    const canvasInstance = globalThis.canvas;
+    if (!canvasInstance?.ready || !canvasInstance.grid) return null;
+
+    const targets = Array.from(game.user.targets ?? []);
+    if (targets.length === 0) return null;
+
+    const targetToken = targets[0];
+    const actorToken = _findActorToken(actorRef, targetToken);
+    if (!actorToken || !targetToken) return null;
+
+    const origin = _getTokenCenter(actorToken);
+    const destination = _getTokenCenter(targetToken);
+    if (!origin || !destination) return null;
+
+    const weaponRange = _normalizeWeaponRange(rollData.weapon.range);
+    if (!Number.isFinite(weaponRange) || weaponRange <= 0) return null;
+
+    const distance = canvasInstance.grid.measureDistance(origin, destination);
+    if (!Number.isFinite(distance)) return null;
+
+    const modifier = _computeRangeModifier(distance, weaponRange);
+    if (modifier === null) return null;
+
+    return { modifier };
+}
+
+function _findActorToken(actorRef, targetToken) {
+    if (!actorRef) return null;
+    if (actorRef.token?.object) return actorRef.token.object;
+
+    const tokens = actorRef.getActiveTokens?.(true) ?? [];
+    const targetSceneId = targetToken?.document?.parent?.id ?? targetToken?.scene?.id ?? null;
+    let candidates = tokens;
+    if (targetSceneId) {
+        const sameScene = tokens.filter(token => (token?.document?.parent?.id ?? token?.scene?.id) === targetSceneId);
+        if (sameScene.length) candidates = sameScene;
+    }
+
+    if (!candidates.length) {
+        const canvasTokens = globalThis.canvas?.tokens?.placeables ?? [];
+        const sceneMatches = canvasTokens.filter(token => token.actor?.id === actorRef.id);
+        if (!sceneMatches.length) return null;
+        candidates = sceneMatches;
+    }
+
+    const controlled = candidates.find(token => token.controlled);
+    if (controlled) return controlled;
+
+    const owned = candidates.find(token => token.isOwner);
+    if (owned) return owned;
+
+    return candidates[0] ?? null;
+}
+
+function _normalizeWeaponRange(rangeValue) {
+    if (rangeValue === null || typeof rangeValue === "undefined") return NaN;
+    if (typeof rangeValue === "number") return rangeValue;
+    if (typeof rangeValue === "object") {
+        const nestedValue = rangeValue.value ?? rangeValue.max ?? rangeValue.min;
+        if (typeof nestedValue !== "undefined") {
+            const numeric = Number(nestedValue);
+            if (!Number.isNaN(numeric)) return numeric;
+        }
+    }
+    const numeric = Number(rangeValue);
+    if (!Number.isNaN(numeric)) return numeric;
+    const match = String(rangeValue).match(/[-+]?[0-9]*\.?[0-9]+/);
+    return match ? Number(match[0]) : NaN;
+}
+
+function _computeRangeModifier(distance, weaponRange) {
+    if (!Number.isFinite(distance) || !Number.isFinite(weaponRange) || weaponRange <= 0) return null;
+
+    const pointBlankLimit = 3;
+    const shortLimit = weaponRange / 2;
+    const standardLimit = weaponRange;
+    const longLimit = weaponRange * 2;
+    const extremeLimit = weaponRange * 3;
+
+    if (distance <= pointBlankLimit) return 30;
+    if (distance <= shortLimit) return 10;
+    if (distance <= standardLimit) return 0;
+    if (distance <= longLimit) return -10;
+    if (distance <= extremeLimit) return -30;
+    return null;
+}
+
+function _getTokenCenter(token) {
+    if (!token) return null;
+    if (token.center) return token.center;
+    if (typeof token.getCenter === "function") return token.getCenter();
+    if (token.object && token.object !== token) {
+        if (token.object.center) return token.object.center;
+        if (typeof token.object.getCenter === "function") return token.object.getCenter();
+    }
+    return null;
 }
 
 /**

--- a/template/dialog/combat-roll.hbs
+++ b/template/dialog/combat-roll.hbs
@@ -27,7 +27,7 @@
             {{#if weapon.isRange}}
             <div class="wrapper">
                 <label>{{localize "DIALOG.RANGE"}}</label>
-                <select id="range">
+                <select id="range" {{#if flags.autoSelectedRange}}class="auto-range-selected"{{/if}}>
                     {{selectOptions (config "ranges") selected=rangeMod localize=true}}
                 </select>
             </div>
@@ -75,5 +75,8 @@
 <script>
     $(".wrapper input").focusin(function () {
         $(this).select();
+    });
+    $("#range").on("change", function () {
+        $(this).removeClass("auto-range-selected");
     });
 </script>


### PR DESCRIPTION
Start of attack automations and mookAI - autocalculate range

## Summary
- determine the default range modifier for ranged weapons by measuring distance to the actor's targeted token
- flag the auto-selected range value in the combat roll dialog and clear the highlight if the user changes it
- add dialog styling to differentiate automatically applied range selections

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68d015168b6483269db9aa9312288ad4