### PR TITLE
Handle ranged weapon jams and overheat damage

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -125,6 +125,10 @@
 
   "CHAT.SUCCESS": "Success!",
   "CHAT.FAILURE": "Failure!",
+  "CHAT.JAM": "Jam!",
+  "CHAT.JAM_AVOIDED": "Jam avoided.",
+  "CHAT.OVERHEAT": "Overheat!",
+  "CHAT.OVERHEAT_NOTE": "The weapon overheats! Apply the damage to the wielder's arm unless they drop it.",
   "CHAT.TEST_MODIFIER": "Modifier",
   "CHAT.ATTACK_RANGE": "Range",
   "CHAT.ATTACK_TYPE": "Type",

--- a/lang/es.json
+++ b/lang/es.json
@@ -105,6 +105,10 @@
 
   "CHAT.SUCCESS": "Exito !",
   "CHAT.FAILURE": "Fallo !",
+  "CHAT.JAM": "¡Se encasquilla!",
+  "CHAT.JAM_AVOIDED": "Encasquillamiento evitado.",
+  "CHAT.OVERHEAT": "¡Se sobrecalienta!",
+  "CHAT.OVERHEAT_NOTE": "¡El arma se recalienta! Aplica el daño al brazo del portador a menos que la haya soltado.",
   "CHAT.TEST_MODIFIER": "Modificador",
   "CHAT.ATTACK_RANGE": "Rango",
   "CHAT.ATTACK_TYPE": "Tipo",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -113,6 +113,10 @@
   
     "CHAT.SUCCESS": "Réussite !",
     "CHAT.FAILURE": "Echec !",
+    "CHAT.JAM": "Enrayement !",
+    "CHAT.JAM_AVOIDED": "Enrayement évité.",
+    "CHAT.OVERHEAT": "Surchauffe !",
+    "CHAT.OVERHEAT_NOTE": "L'arme surchauffe ! Appliquez les dégâts au bras du porteur à moins qu'il ne l'ait lâchée.",
     "CHAT.ROLLED_WITH": "Lancé avec",
     "CHAT.DOS": "Degrés de réussite",
     "CHAT.DOF": "Degrés d'echec",

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -138,6 +138,10 @@
 
   "CHAT.SUCCESS": "Sukces!",
   "CHAT.FAILURE": "Porażka!",
+  "CHAT.JAM": "Zacięcie!",
+  "CHAT.JAM_AVOIDED": "Zacięcie uniknięte.",
+  "CHAT.OVERHEAT": "Przegrzanie!",
+  "CHAT.OVERHEAT_NOTE": "Broń przegrzewa się! Zastosuj obrażenia wobec ramienia władającego, chyba że ją upuścił.",
   "CHAT.TEST_MODIFIER": "Modyfikator",
   "CHAT.ATTACK_RANGE": "Zasięg",
   "CHAT.ATTACK_TYPE": "Typ",

--- a/script/common/roll.js
+++ b/script/common/roll.js
@@ -39,6 +39,7 @@ export async function combatRoll(rollData) {
         await _rollTarget(rollData);
         rollData.attackDos = rollData.dos;
         rollData.attackResult = rollData.result;
+        await _computeJamState(rollData);
         if (!rollData.isReRoll) {
             await _updateRangedAmmo(rollData);
         }
@@ -163,27 +164,10 @@ async function _rollTarget(rollData) {
  * @param {object} rollData
  */
 async function _rollDamage(rollData) {
-    let formula = "0";
+    const damageComponents = _prepareDamageComponents(rollData);
+    const formula = damageComponents.formula;
+    const modifiers = damageComponents.modifiers;
     rollData.damages = [];
-    let modifiers = [];
-    if (rollData.weapon.damageFormula) {
-        formula = rollData.weapon.damageFormula;
-
-        if (rollData.weapon.traits.tearing) {
-            formula = _appendTearing(formula);
-        }
-        if (rollData.weapon.traits.proven) {
-            formula = _appendNumberedDiceModifier(formula, "min", rollData.weapon.traits.proven);
-        }
-        if (rollData.weapon.traits.primitive) {
-            formula = _appendNumberedDiceModifier(formula, "max", rollData.weapon.traits.primitive);
-        }
-
-        formula = `${formula}+${rollData.weapon.damageBonus}`;
-        modifiers = _extractDamageModifiers(formula);
-        formula = _replaceSymbols(formula, rollData);
-    }
-
 
     let penetration = await _rollPenetration(rollData);
 
@@ -232,6 +216,35 @@ async function _rollDamage(rollData) {
 }
 
 /**
+ * Prepare the resolved damage formula and modifiers for a roll.
+ * @param {object} rollData
+ * @returns {{formula: string, modifiers: Array<string>}}
+ */
+function _prepareDamageComponents(rollData) {
+    let formula = "0";
+    let modifiers = [];
+    if (rollData.weapon.damageFormula) {
+        formula = rollData.weapon.damageFormula;
+
+        if (rollData.weapon.traits.tearing) {
+            formula = _appendTearing(formula);
+        }
+        if (rollData.weapon.traits.proven) {
+            formula = _appendNumberedDiceModifier(formula, "min", rollData.weapon.traits.proven);
+        }
+        if (rollData.weapon.traits.primitive) {
+            formula = _appendNumberedDiceModifier(formula, "max", rollData.weapon.traits.primitive);
+        }
+
+        formula = `${formula}+${rollData.weapon.damageBonus}`;
+        modifiers = _extractDamageModifiers(formula);
+        formula = _replaceSymbols(formula, rollData);
+    }
+
+    return { formula, modifiers };
+}
+
+/**
  * Calculates the amount of hits of a successful attack
  * @param {int} attackDos Degrees of success on the Attack
  * @param {int} evasionDos Degrees of success on the Evasion
@@ -268,6 +281,106 @@ function _computeNumberOfHits(attackDos, evasionDos, attackType, shotsFired, wea
     } else {
         return hits;
     }
+}
+
+/**
+ * Determine whether a ranged attack jams or overheats and update roll data.
+ * @param {object} rollData
+ */
+async function _computeJamState(rollData) {
+    if (!rollData.weapon?.isRange) {
+        return;
+    }
+
+    rollData.flags = rollData.flags ?? {};
+    rollData.flags.jam = false;
+    rollData.flags.overheat = false;
+    rollData.flags.jamAvoided = false;
+    delete rollData.overheat;
+
+    const threshold = _getJamThreshold(rollData);
+    if (threshold === null) {
+        return;
+    }
+
+    const result = rollData.result ?? 0;
+    const traits = rollData.weapon.traits ?? {};
+
+    // Reliable weapons may still display that a jam was avoided even on a success.
+    if (traits.reliable && result >= threshold && result !== 100) {
+        rollData.flags.jamAvoided = true;
+        if (rollData.flags.isSuccess) {
+            return;
+        }
+    }
+
+    if (rollData.flags.isSuccess || result < threshold) {
+        return;
+    }
+
+    if (traits.reliable && result !== 100) {
+        // Reliable weapons avoid the jam unless the roll is 100.
+        return;
+    }
+
+    if (traits.overheat) {
+        rollData.flags.overheat = true;
+        rollData.overheat = await _computeOverheatDamage(rollData);
+    } else {
+        rollData.flags.jam = true;
+    }
+}
+
+/**
+ * Get the threshold at which a ranged attack jams.
+ * @param {object} rollData
+ * @returns {number|null}
+ */
+function _getJamThreshold(rollData) {
+    if (!rollData.weapon?.isRange) {
+        return null;
+    }
+
+    const traits = rollData.weapon.traits ?? {};
+    if (traits.unreliable) {
+        return 91;
+    }
+
+    let threshold = traits.primitive ? 94 : 96;
+    const attackType = rollData.attackType?.name;
+    if (attackType === "semi_auto" || attackType === "full_auto") {
+        threshold = Math.min(threshold, 94);
+    }
+
+    return threshold;
+}
+
+/**
+ * Compute the damage dealt to the wielder by an overheating weapon.
+ * @param {object} rollData
+ * @returns {Promise<object>}
+ */
+async function _computeOverheatDamage(rollData) {
+    const damageComponents = _prepareDamageComponents(rollData);
+    const penetration = await _rollPenetration(rollData);
+    const damage = await _computeDamage(
+        damageComponents.formula,
+        penetration,
+        0,
+        false,
+        rollData.weapon.traits,
+        damageComponents.modifiers
+    );
+    damage.location = "ARMOUR.RIGHT_ARM";
+
+    return {
+        itemName: rollData.itemName,
+        weapon: {
+            damageType: rollData.weapon.damageType,
+            special: rollData.weapon.special
+        },
+        damages: [damage]
+    };
 }
 
 /**
@@ -691,6 +804,13 @@ function _sanitizeRollData(rollData) {
     delete cleaned.render;
     if (Array.isArray(cleaned.damages)) {
         cleaned.damages.forEach(d => {
+            delete d.damageRoll;
+            delete d.damageRender;
+            delete d.accurateRender;
+        });
+    }
+    if (Array.isArray(cleaned.overheat?.damages)) {
+        cleaned.overheat.damages.forEach(d => {
             delete d.damageRoll;
             delete d.damageRender;
             delete d.accurateRender;

--- a/script/common/util.js
+++ b/script/common/util.js
@@ -162,12 +162,15 @@ export default class DarkHeresyUtil {
             rfFace: this.extractNumberedTrait(/Vengeful.*\(\d\)/gi, traits), // The alternativ die face Righteous Fury is triggered on
             proven: this.extractNumberedTrait(/Proven.*\(\d\)/gi, traits),
             primitive: this.extractNumberedTrait(/Primitive.*\(\d\)/gi, traits),
+            reliable: this.hasNamedTrait(/Reliable/gi, traits),
             razorSharp: this.hasNamedTrait(/Razor.?-? *Sharp/gi, traits),
+            overheat: this.hasNamedTrait(/Overheat/gi, traits),
             spray: this.hasNamedTrait(/Spray/gi, traits),
             skipAttackRoll: this.hasNamedTrait(/Spray/gi, traits), // Currently, spray will always be the same as skipAttackRoll. However, in the future, there may be other skipAttackRoll weapons that are not Spray.
             tearing: this.hasNamedTrait(/Tearing/gi, traits),
             storm: this.hasNamedTrait(/Storm/gi, traits),
             twinLinked: this.hasNamedTrait(/Twin.?-? *Linked/gi, traits),
+            unreliable: this.hasNamedTrait(/Unreliable/gi, traits),
             force: this.hasNamedTrait(/Force/gi, traits),
             inaccurate: this.hasNamedTrait(/Inaccurate/gi, traits)
         };

--- a/template/chat/roll.hbs
+++ b/template/chat/roll.hbs
@@ -12,6 +12,44 @@
         {{else}}
         <h3 style="color: var(--color-failure)">{{localize "CHAT.FAILURE"}} <span>({{result}})</span></h3>
         {{/if}}
+        {{#if flags.jam}}
+            <p class="jam-message" style="color: var(--color-failure); font-weight: bold;">{{localize "CHAT.JAM"}}</p>
+        {{/if}}
+        {{#if flags.overheat}}
+            <p class="jam-message" style="color: var(--color-failure); font-weight: bold;">{{localize "CHAT.OVERHEAT"}}</p>
+            <p>{{localize "CHAT.OVERHEAT_NOTE"}}</p>
+            {{#each overheat.damages as |damage|}}
+                <div class="dice-rolls">
+                    <p><strong>{{localize "CHAT.DAMAGE_HEADER"}}</strong></p>
+                    <ul class="dice-list">
+                        {{#each damage.dice as |die|}}
+                            <li class="die {{#if die.max}}max{{/if}} {{#if die.righteous}}righteous{{/if}} {{#if die.replaced}}replaced-{{die.replaced}}{{/if}} {{#if die.dropped}}dropped{{/if}}">{{die.value}}{{#if die.annotation}}<sup>{{die.annotation}}</sup>{{/if}}</li>
+                        {{/each}}
+                    </ul>
+                    {{#each damage.modifiers as |mod|}}
+                        <p class="damage-modifier">{{mod}}</p>
+                    {{/each}}
+                </div>
+                <h3 class="separator damage-location" data-location={{damage.location}}>{{localize damage.location}}</h3>
+                <div>
+                    <p><strong>{{localize "CHAT.DAMAGE"}}:</strong> <span class="damage-total">{{damage.total}}</span> <strong class="damage-type">{{damageTypeShort ../overheat.weapon.damageType}}</strong></p>
+                </div>
+                <p><strong>{{localize "CHAT.PENETRATION"}}:</strong> <span class="damage-penetration">{{damage.penetration}}</span></p>
+                {{#if damage.righteousFury}}
+                    <p><strong>{{localize "CHAT.RIGHTEOUS_FURY"}}:</strong> <span class="damage-righteous-fury">{{damage.righteousFury}}</span></p>
+                {{/if}}
+            {{/each}}
+            {{#if overheat.weapon.special}}
+                <h3 class="separator">{{localize "WEAPON.SPECIAL"}}</h3>
+                <p class="weapon-special">{{overheat.weapon.special}}</p>
+            {{/if}}
+            <div class="wrapper flex-column">
+                <button class="apply-damage">{{localize "CHAT.CONTEXT.APPLY_DAMAGE"}}</button>
+            </div>
+        {{/if}}
+        {{#if flags.jamAvoided}}
+            <p class="jam-message" style="color: var(--color-success); font-weight: bold;">{{localize "CHAT.JAM_AVOIDED"}}</p>
+        {{/if}}
 
         <p><strong>{{localize "CHAT.TEST_MODIFIER"}}:</strong> {{target.modifier}}</p>
 


### PR DESCRIPTION
## Summary
- add ranged jam detection that respects reliable, unreliable, and overheat traits and prepares shared damage helpers
- extend weapon trait extraction so roll data exposes reliable, unreliable, and overheat flags
- show jam, jam-avoided, and overheat damage details in the ranged attack chat card with localized strings

## Testing
- npm run lint *(produces numerous warnings from the vendored jquery-3.7.1.min.js file)*

------
https://chatgpt.com/codex/tasks/task_b_68d2d05b2ce083269880072a92a6ab90