### PR TITLE
Add system guide, changelog, feature status, and rules reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+This project keeps a human-readable changelog focused on the 0.4 release line described in `AGENTS.md`.
+
+## [0.4.0] - 2026-01-24
+
+### Added
+- A system guide viewer at the repository root (`system-guide.html`) that links to the new documentation set.
+- A feature inventory with explicit implementation status markers in `FEATURE_STATUS.md`.
+- A rules reference that documents the system behavior currently inferred from the automation code in `RULES_REFERENCE.md`.
+
+### Notes
+- Version 0.4 work is centered on auto-attack tooling and NPC/minion automation workflows, and the legacy `mookAI-12-master` folder is preserved as a reference.

--- a/FEATURE_STATUS.md
+++ b/FEATURE_STATUS.md
@@ -1,0 +1,35 @@
+# Feature Status
+
+Status legend: **Working**, **Bugged**, **Not Implemented**.
+
+## Combat and Automation
+
+| Area | Status | Notes |
+| --- | --- | --- |
+| Combat roll target calculation (aim, range, RoF, caps at ±60) | Working | Implemented in `_computeCombatTarget` and `_getRollTarget`. |
+| Multi-hit computation (semi/full auto, storm, twin-linked, evasion reduction) | Working | Implemented in `_computeNumberOfHits`. |
+| Hit location resolution (reverse digits) and additional hit mapping | Working | Implemented in `_getLocation` and `_getAdditionalLocation`. |
+| Damage trait handling (Tearing, Proven, Primitive, Accurate, Razor Sharp, Righteous Fury) | Working | Implemented during `_rollDamage`, `_appendTearing`, `_appendNumberedDiceModifier`, `_rollPenetration`, and `_computeDamage`. |
+| Ammo consumption for ranged attacks (standard/semi/full auto, storm/twin-linked) | Working | Implemented in `_updateRangedAmmo`. |
+| Chat-card fate rerolls | Working | Implemented in `rerollTest` and enabled via `rollData.canReroll`. |
+| NPC auto-target selection modes and range modifier resolution | Working | Implemented in `selectHostileTarget`, `computeRangeModifier`, and `resolveRangeSelection`. |
+| Programmatic damage application from roll data (`applyDamage(rollData)`) | Bugged | `rollData.damages` uses `damage.total` while `Actor.applyDamage` expects `damage.amount`. This mismatch can yield `NaN` wounds when applying damage directly from roll data. |
+
+## Sheets, Data, and Derived Stats
+
+| Area | Status | Notes |
+| --- | --- | --- |
+| Characteristic totals and bonuses (including cybernetics and fatigue halving) | Working | Implemented in `_computeCharacteristics`. |
+| Skill totals and specialist handling | Working | Implemented in `_computeSkills`. |
+| Experience auto-calculation option | Working | Implemented in `_computeExperience_auto` with fallback to `_computeExperience_normal`. |
+| Armour aggregation by hit location and AP lookup during damage | Working | Implemented in `_computeArmour` and `_getArmour`. |
+| Critical message prompting on overflow damage | Working | Implemented in `_showCritMessage`. |
+
+## Documentation and Guidance
+
+| Area | Status | Notes |
+| --- | --- | --- |
+| Changelog | Working | Added `CHANGELOG.md`. |
+| Feature inventory with status flags | Working | This file (`FEATURE_STATUS.md`). |
+| Rules reference derived from the automation code | Working | Added `RULES_REFERENCE.md`. |
+| Root HTML guide viewer | Working | Added `system-guide.html` to link everything together. |

--- a/RULES_REFERENCE.md
+++ b/RULES_REFERENCE.md
@@ -1,0 +1,201 @@
+# Rules Reference (Inferred from Automation Code)
+
+This document records system behavior as it is currently implemented in the codebase, especially around attack rolls, multi-hit logic, and damage application.
+
+> Source of truth: the implementation in `script/common/roll.js`, `script/common/dialog.js`, `script/common/chat.js`, `script/common/actor.js`, and `script/macro/auto-npc.js`.
+
+## 1) Target Numbers and Modifiers
+
+### Modifier cap
+- Total modifiers are capped at **+60 / -60** before being applied to the base target.
+- The final target is `baseTarget + clamp(targetMods, -60, +60)`.
+
+### Combat target formula
+The combat target combines:
+- Manual modifier from the dialog (`rollData.target.modifier`).
+- Aim modifier (`rollData.aim.val`).
+- Range modifier (`rollData.rangeMod`).
+- Twin-linked bonus (**+20**).
+- Attack type modifier (based on RoF/mode).
+- Psychic modifier: `(psy.rating - psy.value) * 10`, with push handling.
+
+## 2) Attack Type / Rate of Fire Rules
+
+Attack type drives three key values:
+- `modifier`: to-hit modifier.
+- `hitMargin`: degrees-of-success step per additional hit.
+- `maxHits`: ceiling on the number of hits before other traits (e.g., Storm).
+
+### Implemented attack types
+- **Standard**: `+10`, margin `1`, max hits `1`.
+- **Semi-auto / Swift / Barrage**: `0`, margin `2`, max hits = burst RoF.
+- **Full-auto / Lightning**: `-10`, margin `1`, max hits = full RoF.
+- **Called shot**: `-20`, margin `1`, max hits `1`.
+- **Charge**: `+20`, margin `1`, max hits `1`.
+- **All-out**: `+30`, margin `1`, max hits `1`.
+- **Bolt / Blast**: `0`, margin `1`, max hits `1`.
+
+## 3) Degrees of Success / Failure
+
+### Success test
+- A roll succeeds if `d100 <= target.final`.
+- On success:
+  - `dos = 1 + (floor(target.final / 10) - floor(result / 10))`.
+  - `dof = 0`.
+- On failure:
+  - `dos = 0`.
+  - `dof = 1 + (floor(result / 10) - floor(target.final / 10))`.
+
+## 4) Multi-hit Resolution
+
+The number of hits starts from degrees of success and attack type, then is adjusted by traits and constraints.
+
+### Core hit formula
+- Base hits are computed as:
+  - `hits = (1 + floor((attackDos - 1) / hitMargin)) * stormMod`
+  - where `stormMod = 2` if the weapon has **Storm**, else `1`.
+
+### Twin-linked adjustments
+If **Twin-linked** and the attack has at least 2 DoS:
+- `maxHits += 1`
+- `attackDos += hitMargin`
+- `shotsFired += 1` (when available)
+
+### Constraints and reductions
+- Hits are capped to `maxHits` (and to `shotsFired` if ammo ran short).
+- Evasion DoS subtracts directly from hits.
+- Hits never go below zero.
+
+## 5) Hit Locations
+
+### First hit location (reversed roll)
+- The d100 result is reversed (e.g., `05 -> 50`) to determine location.
+- Location mapping:
+  - `01-10`: Head
+  - `11-20`: Right Arm
+  - `21-30`: Left Arm
+  - `31-70`: Body
+  - `71-85`: Right Leg
+  - `86-100`: Left Leg
+
+### Additional hit locations
+- Additional hits follow a fixed lookup table based on the first hit location.
+- Once the sequence runs out, it repeats the last entry.
+
+## 6) Damage Formula Construction
+
+### Step-by-step construction
+When a weapon has a damage formula:
+1. Start with `weapon.damageFormula`.
+2. Apply special traits:
+   - **Tearing**: add one die and drop the lowest.
+   - **Proven (X)**: add `minX` to the damage dice term.
+   - **Primitive (X)**: add `maxX` to the damage dice term.
+3. Append flat bonus: `+ weapon.damageBonus`.
+4. Extract display modifiers (e.g., `+SB`, `+5`) for the chat card.
+5. Replace symbols using actor bonuses and `PR` (psy rating).
+
+## 7) Weapon Trait Behavior
+
+### Tearing
+- Implemented by increasing the number of dice by 1 and adding `dl` (drop lowest).
+- It only applies if the formula does not already include `dl` or `kh`.
+
+### Proven (X)
+- Adds `minX` to the damage dice term.
+- Dice results below X are raised up to X by the dice engine.
+
+### Primitive (X)
+- Adds `maxX` to the damage dice term.
+- Dice results above X are reduced down to X by the dice engine.
+
+### Accurate (when aiming)
+- If aiming and the weapon is Accurate:
+  - Additional damage dice are added based on DoS beyond the first.
+  - Extra dice count is `floor((dos - 1) / 2)`, capped at 2 dice.
+
+### Inaccurate
+- Inaccurate weapons set aim bonus to 0.
+
+### Storm
+- Storm doubles both computed hits and max hits via `stormMod = 2`.
+
+### Twin-linked
+- Twin-linked provides:
+  - A flat **+20** to hit.
+  - Extra multi-hit handling when DoS >= 2.
+  - Ammo consumption doubled (shared with Storm logic).
+
+### Razor Sharp
+- If DoS >= 3 and the weapon has Razor Sharp, penetration is doubled.
+- Legacy support: a penetration value in parentheses like `6(12)` will switch to the parenthetical value when DoS >= 3.
+
+### Vengeful / Righteous Fury face
+- Righteous Fury triggers when a die meets or exceeds `rfFace`.
+- If `rfFace` is not present, the die's full face value is used.
+- Righteous Fury adds an extra `1d5` value that is tracked separately.
+
+## 8) Penetration Rules
+
+- Penetration uses `weapon.penetrationFormula` if present, otherwise 0.
+- The formula supports attribute symbols and `PR` replacement.
+- Razor Sharp (or legacy parenthetical syntax) may double penetration at 3+ DoS.
+
+## 9) Righteous Fury Handling
+
+- Each qualifying damage die can trigger a `1d5` Righteous Fury roll.
+- When damage would be fully soaked but Righteous Fury is present, at least **1 wound** is applied.
+- When damage penetrates and Righteous Fury is present, a "Critical Effect (RF)" entry is recorded for chat output.
+
+## 10) Ammo Consumption
+
+Ammo reduction occurs for ranged attacks when the weapon has a clip.
+
+- Standard / called shot: consume 1 shot.
+- Semi-auto: consume `burst * mod` shots.
+- Full-auto: consume `full * mod` shots.
+- `mod = 2` if the weapon is Storm or Twin-linked, otherwise 1.
+- If there is insufficient ammo, `shotsFired` is set to the remaining clip, and the clip drops to 0.
+
+## 11) Damage Application to Actors
+
+### Soak and wounds
+When applying damage to an actor:
+1. Armour is fetched by hit location.
+2. Penetration reduces armour, but never below 0.
+3. Damage is reduced by Toughness Bonus first.
+4. Remaining damage is reduced by armour.
+5. Overflow beyond max wounds becomes critical wounds.
+
+### Important implementation mismatch
+- `DarkHeresyActor.applyDamage` expects each damage entry to include `damage.amount`.
+- Damage rolls currently produce `damage.total`.
+- This mismatch can produce `NaN` results when damage is applied programmatically from roll data instead of from the chat-card parser.
+
+## 12) Auto-NPC Targeting and Range Bands
+
+### Target selection modes
+The auto-NPC macro supports:
+- closest, targeted, random, weakest, strongest
+
+### Actor-type filters
+- any, npc, acolyte
+
+### Range bands and modifiers
+Range modifiers are derived from measured token distance and weapon range:
+- ≤ 3m: +30 (Point Blank)
+- ≤ 1/2 range: +10 (Short)
+- ≤ range: +0 (Standard)
+- ≤ 2x range: -10 (Long)
+- ≤ 3x range: -30 (Extreme)
+- Beyond 3x range: no valid modifier returned
+
+## 13) File References
+
+Primary references for the rules above:
+- `script/common/roll.js`
+- `script/common/dialog.js`
+- `script/common/chat.js`
+- `script/common/actor.js`
+- `script/macro/auto-npc.js`
+- `template/chat/damage.hbs`

--- a/system-guide.html
+++ b/system-guide.html
@@ -1,0 +1,343 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Dark Heresy System Guide</title>
+  <style>
+    :root {
+      --bg: #050b05;
+      --panel: #0b160b;
+      --panel-2: #0f1f0f;
+      --text: #d7f7d7;
+      --muted: #8fbf8f;
+      --accent: #3cff6b;
+      --accent-2: #1faa4a;
+      --border: #1d3b1d;
+      --warning: #ffcc66;
+      --bad: #ff6b6b;
+      --shadow: rgba(0, 255, 128, 0.12);
+    }
+
+    * { box-sizing: border-box; }
+
+    body {
+      margin: 0;
+      font-family: "Inter", "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+      background:
+        radial-gradient(1200px 600px at 20% -10%, rgba(60, 255, 107, 0.08), transparent 60%),
+        radial-gradient(900px 500px at 120% 10%, rgba(60, 255, 107, 0.05), transparent 65%),
+        var(--bg);
+      color: var(--text);
+      line-height: 1.55;
+    }
+
+    a { color: var(--accent); }
+    a:hover { color: #7dff9a; }
+
+    header {
+      padding: 3.25rem 1.5rem 2.25rem;
+      border-bottom: 1px solid var(--border);
+      background: linear-gradient(180deg, rgba(15, 35, 15, 0.85), rgba(5, 11, 5, 0.92));
+      position: sticky;
+      top: 0;
+      backdrop-filter: blur(6px);
+      z-index: 10;
+    }
+
+    .wrap {
+      max-width: 1100px;
+      margin: 0 auto;
+    }
+
+    .kicker {
+      text-transform: uppercase;
+      letter-spacing: 0.18em;
+      font-size: 0.75rem;
+      color: var(--muted);
+      margin-bottom: 0.75rem;
+    }
+
+    h1 {
+      margin: 0 0 0.5rem;
+      font-size: clamp(2rem, 4vw, 3rem);
+      line-height: 1.05;
+      color: var(--accent);
+      text-shadow: 0 0 24px var(--shadow);
+    }
+
+    .subtitle {
+      margin: 0.25rem 0 0;
+      color: var(--muted);
+      max-width: 70ch;
+    }
+
+    nav {
+      margin-top: 1.5rem;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.6rem;
+    }
+
+    nav a {
+      text-decoration: none;
+      border: 1px solid var(--border);
+      padding: 0.55rem 0.75rem;
+      border-radius: 0.6rem;
+      background: var(--panel);
+      color: var(--text);
+      font-weight: 600;
+      transition: all 120ms ease;
+    }
+
+    nav a:hover {
+      border-color: var(--accent-2);
+      transform: translateY(-1px);
+      box-shadow: 0 12px 24px -18px var(--shadow);
+    }
+
+    main {
+      padding: 2.2rem 1.5rem 4rem;
+    }
+
+    section {
+      margin: 0 0 2rem;
+      padding: 1.4rem 1.4rem 1.6rem;
+      background: linear-gradient(180deg, var(--panel), var(--panel-2));
+      border: 1px solid var(--border);
+      border-radius: 1rem;
+      box-shadow: 0 24px 40px -36px var(--shadow);
+    }
+
+    h2 {
+      margin: 0 0 0.75rem;
+      color: var(--accent);
+      font-size: clamp(1.35rem, 2.4vw, 1.8rem);
+    }
+
+    h3 {
+      margin: 1.1rem 0 0.4rem;
+      color: #b6ffbf;
+      font-size: 1.05rem;
+    }
+
+    p { margin: 0.5rem 0; }
+
+    ul {
+      margin: 0.6rem 0 0.2rem 1.1rem;
+      padding: 0;
+    }
+
+    li { margin: 0.35rem 0; }
+
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+      gap: 1rem;
+      margin-top: 1rem;
+    }
+
+    .card {
+      border: 1px solid var(--border);
+      border-radius: 0.85rem;
+      padding: 1rem 1rem 1.1rem;
+      background: rgba(12, 26, 12, 0.85);
+      min-height: 140px;
+      display: flex;
+      flex-direction: column;
+      gap: 0.4rem;
+    }
+
+    .card h3 {
+      margin: 0 0 0.25rem;
+    }
+
+    .status {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.4rem;
+      font-weight: 700;
+      font-size: 0.92rem;
+      padding: 0.25rem 0.55rem;
+      border-radius: 999px;
+      border: 1px solid transparent;
+      width: fit-content;
+    }
+
+    .status.working {
+      color: #b9ffbf;
+      border-color: rgba(60, 255, 107, 0.4);
+      background: rgba(60, 255, 107, 0.12);
+    }
+
+    .status.bugged {
+      color: #ffe0a3;
+      border-color: rgba(255, 204, 102, 0.5);
+      background: rgba(255, 204, 102, 0.12);
+    }
+
+    .status.missing {
+      color: #ffb3b3;
+      border-color: rgba(255, 107, 107, 0.5);
+      background: rgba(255, 107, 107, 0.12);
+    }
+
+    code, pre {
+      font-family: "JetBrains Mono", "Fira Code", ui-monospace, SFMono-Regular, Menlo, monospace;
+      background: rgba(18, 40, 18, 0.9);
+      border: 1px solid var(--border);
+      border-radius: 0.6rem;
+    }
+
+    code {
+      padding: 0.1rem 0.35rem;
+      font-size: 0.95em;
+    }
+
+    pre {
+      padding: 0.8rem 0.9rem;
+      overflow-x: auto;
+      margin: 0.6rem 0 0.9rem;
+    }
+
+    .callout {
+      border-left: 4px solid var(--accent);
+      padding: 0.75rem 0.9rem;
+      background: rgba(60, 255, 107, 0.08);
+      border-radius: 0.6rem;
+      margin: 0.9rem 0 0.6rem;
+    }
+
+    footer {
+      color: var(--muted);
+      padding: 2rem 1.5rem 3rem;
+      border-top: 1px solid var(--border);
+      text-align: center;
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="wrap">
+      <div class="kicker">Foundry VTT • Dark Heresy 2E</div>
+      <h1>System Guide &amp; Status Board</h1>
+      <p class="subtitle">
+        A single entry point for the current automation rules, feature status, and release notes.
+        This viewer is designed to be readable in the classic 40k green-on-black aesthetic.
+      </p>
+      <nav>
+        <a href="#release">Release Focus</a>
+        <a href="#docs">Documentation Map</a>
+        <a href="#combat">Combat Rules Snapshot</a>
+        <a href="#status">Feature Status Highlights</a>
+        <a href="#workflow">Suggested Workflow</a>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <div class="wrap">
+      <section id="release">
+        <h2>Release Focus</h2>
+        <p>
+          The current documentation set is organized around the 0.4 release focus:
+          auto-attack tooling and NPC/minion automation scripting for combat workflows.
+        </p>
+        <div class="callout">
+          The legacy <code>mookAI-12-master</code> folder is intentionally preserved as a reference while new
+          Dark Heresy-specific automation is documented and extended.
+        </div>
+      </section>
+
+      <section id="docs">
+        <h2>Documentation Map</h2>
+        <p>Start here, then branch out to the detailed references.</p>
+        <div class="grid">
+          <article class="card">
+            <h3>Changelog</h3>
+            <p>Release-scoped notes for the documentation pass and 0.4 tracking.</p>
+            <p><a href="./CHANGELOG.md">Open CHANGELOG.md</a></p>
+          </article>
+          <article class="card">
+            <h3>Feature Status</h3>
+            <p>A working/bugged/not implemented ledger for core system capabilities.</p>
+            <p><a href="./FEATURE_STATUS.md">Open FEATURE_STATUS.md</a></p>
+          </article>
+          <article class="card">
+            <h3>Rules Reference</h3>
+            <p>Behavior inferred from the automation code, with emphasis on attack and damage rules.</p>
+            <p><a href="./RULES_REFERENCE.md">Open RULES_REFERENCE.md</a></p>
+          </article>
+        </div>
+      </section>
+
+      <section id="combat">
+        <h2>Combat Rules Snapshot</h2>
+        <p>
+          These highlights mirror the currently implemented logic in <code>script/common/roll.js</code>
+          and related files. Use the rules reference for the complete detail.
+        </p>
+
+        <h3>Target number assembly</h3>
+        <ul>
+          <li>Combat modifiers are capped to <strong>±60</strong> before applying to the base target.</li>
+          <li>Attack type, aim, range, twin-linked, and psychic modifiers all stack into the final target.</li>
+        </ul>
+
+        <h3>Multi-hit behavior</h3>
+        <ul>
+          <li>Semi-auto uses a hit margin of 2; full-auto uses a hit margin of 1.</li>
+          <li>Storm doubles hits; twin-linked adds accuracy and can add extra hits at 2+ DoS.</li>
+          <li>Evasion degrees of success reduce total hits directly.</li>
+        </ul>
+
+        <h3>Damage traits</h3>
+        <ul>
+          <li><strong>Tearing</strong>: adds a die and drops the lowest.</li>
+          <li><strong>Proven / Primitive</strong>: enforced through dice modifiers.</li>
+          <li><strong>Accurate</strong>: adds up to 2d10 extra damage when aiming with sufficient DoS.</li>
+          <li><strong>Razor Sharp</strong>: can double penetration at 3+ DoS.</li>
+        </ul>
+      </section>
+
+      <section id="status">
+        <h2>Feature Status Highlights</h2>
+        <p>For the full table, open the feature status document.</p>
+        <div class="grid">
+          <article class="card">
+            <div class="status working">● Working</div>
+            <h3>Core attack &amp; damage flow</h3>
+            <p>Combat targets, multi-hit resolution, location rolls, and trait-aware damage rolls are in place.</p>
+          </article>
+          <article class="card">
+            <div class="status working">● Working</div>
+            <h3>NPC targeting automation</h3>
+            <p>Auto-target selection and range band modifiers are implemented for hostile tokens.</p>
+          </article>
+          <article class="card">
+            <div class="status bugged">▲ Bugged</div>
+            <h3>Programmatic damage application</h3>
+            <p>The roll-data damage payload uses <code>total</code> while actor damage expects <code>amount</code>.</p>
+          </article>
+        </div>
+      </section>
+
+      <section id="workflow">
+        <h2>Suggested Workflow</h2>
+        <ol>
+          <li>Open <a href="./FEATURE_STATUS.md">FEATURE_STATUS.md</a> to see what is safe to rely on.</li>
+          <li>Use <a href="./RULES_REFERENCE.md">RULES_REFERENCE.md</a> as the behavior contract for automation work.</li>
+          <li>Track any rule changes in <a href="./CHANGELOG.md">CHANGELOG.md</a> to keep future debugging focused.</li>
+        </ol>
+        <pre><code># Quick local preview
+python -m http.server 4173
+# Then open http://localhost:4173/system-guide.html</code></pre>
+      </section>
+    </div>
+  </main>
+
+  <footer>
+    Dark Heresy 2E system documentation viewer • root file: <code>system-guide.html</code>
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
### Motivation

- Provide a single, repository-root documentation entry point and baseline changelog for the 0.4 workstream focused on auto-attack/NPC automation.  
- Capture and publish an explicit feature inventory with working/bugged/not implemented statuses so maintainers know what to trust for automation.  
- Codify the rules inferred from the existing automation code (attack, multi-hit, damage, traits, penetration, etc.) to serve as a stable contract for further automation.  
- Deliver a readable, 40k green-on-black HTML viewer as a convenient first-stop guide for contributors and world-builders.

### Description

- Added a root documentation viewer at `system-guide.html` with a 40k-themed style and links to the new reference docs.  
- Added `CHANGELOG.md` that anchors the 0.4 documentation baseline and notes the NPC/auto-attack focus.  
- Added `FEATURE_STATUS.md` containing a ledger of feature areas with status markers and concise notes (includes flagging a programmatic damage payload mismatch).  
- Added `RULES_REFERENCE.md` documenting inferred rules and behaviors from `script/common/roll.js`, `script/common/dialog.js`, `script/common/chat.js`, `script/common/actor.js`, and `script/macro/auto-npc.js` (covers target assembly, DoS/DoF, multi-hit, hit locations, traits like Tearing, penetration, RF, and ammo rules).

### Testing

- Ran the automated lint/test pipeline with `npm run test` (which runs `gulp lint --fix`) and it completed successfully with lint warnings only (lint reported 1409 warnings) which do not block this documentation addition.  
- No code-path or runtime changes were made to core game logic; only documentation and viewer files were added, so no additional automated unit tests were required for this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974bb441cbc8327b336104700dcb745)