### PR TITLE
Add built-in attack window macro suite

### DIFF
--- a/script/dark-heresy.js
+++ b/script/dark-heresy.js
@@ -30,6 +30,7 @@ import Dh from "./common/config.js";
 import { registerFactionTokenHud } from "./common/token-hud.js";
 import { HordeFightManager } from "./common/horde-fight.js";
 import "./macro/auto-npc.js";
+import { registerAttackWindows } from "./macro/attack-windows/index.js";
 
 // Import Helpers
 
@@ -51,6 +52,7 @@ Hooks.once("init", function() {
         }
     };
     game.macro = DhMacroUtil;
+    registerAttackWindows();
     Actors.unregisterSheet("core", ActorSheet);
     Actors.registerSheet("dark-heresy", AcolyteSheet, { types: ["acolyte"], makeDefault: true });
     Actors.registerSheet("dark-heresy", NpcSheet, { types: ["npc"], makeDefault: true });

--- a/script/macro/attack-windows/common.js
+++ b/script/macro/attack-windows/common.js
@@ -1,0 +1,571 @@
+import DarkHeresyUtil from "../../common/util.js";
+import { PlaceableTemplate } from "../../common/placeable-template.js";
+
+export const COVER_LEVELS = Object.freeze([4, 8, 12, 16, 20, 32, 64]);
+export const COVER_ITEM_NAME = "Cover";
+export const DENY_THE_WITCH_NAME = "Deny the Witch";
+
+export const HIT_LOCATION_TABLE = Object.freeze([
+    { max: 10, key: "head", label: "Head", armour: "ARMOUR.HEAD" },
+    { max: 20, key: "leftArm", label: "Left Arm", armour: "ARMOUR.LEFT_ARM" },
+    { max: 30, key: "rightArm", label: "Right Arm", armour: "ARMOUR.RIGHT_ARM" },
+    { max: 40, key: "leftLeg", label: "Left Leg", armour: "ARMOUR.LEFT_LEG" },
+    { max: 50, key: "rightLeg", label: "Right Leg", armour: "ARMOUR.RIGHT_LEG" },
+    { max: 100, key: "body", label: "Torso", armour: "ARMOUR.BODY" }
+]);
+
+const MELEE_CLASSES = new Set(["melee", "pistol"]);
+const RANGED_CLASSES = new Set(["pistol", "thrown", "heavy", "basic", "launched", "placed", "vehicle"]);
+
+/**
+ * Attempt to resolve the acting token and actor for the current user.
+ * Prefers controlled tokens, then the chat speaker.
+ * @returns {{token: Token|null, actor: Actor|null}}
+ */
+export function resolveActorContext() {
+    const controlled = canvas?.tokens?.controlled ?? [];
+    if (controlled.length) {
+        const token = controlled[0];
+        return { token, actor: token.actor ?? null };
+    }
+
+    const speaker = ChatMessage.getSpeaker();
+    let actor = speaker.token ? game.actors.tokens[speaker.token] : null;
+    if (!actor && speaker.actor) actor = game.actors.get(speaker.actor);
+    const token = actor?.getActiveTokens?.(true, true)?.[0] ?? null;
+    return { token, actor: actor ?? null };
+}
+
+/**
+ * Build common characteristic lookup helpers so macros can easily access core stats.
+ * @param {Actor} actor
+ * @returns {Record<string, object>}
+ */
+export function buildCharacteristicLookup(actor) {
+    const characteristics = actor?.characteristics ?? actor?.system?.characteristics ?? {};
+    return {
+        weaponSkill: characteristics.weaponSkill,
+        ballisticSkill: characteristics.ballisticSkill,
+        strength: characteristics.strength,
+        toughness: characteristics.toughness,
+        agility: characteristics.agility,
+        intelligence: characteristics.intelligence,
+        perception: characteristics.perception,
+        willpower: characteristics.willpower,
+        fellowship: characteristics.fellowship,
+        influence: characteristics.influence
+    };
+}
+
+/**
+ * Obtain the center point of a token.
+ * @param {Token} token
+ * @returns {{x: number, y: number}|null}
+ */
+export function getTokenCenter(token) {
+    if (!token) return null;
+    if (token.center) return token.center;
+    if (typeof token.getCenter === "function") return token.getCenter();
+    if (token.object && token.object !== token) {
+        if (token.object.center) return token.object.center;
+        if (typeof token.object.getCenter === "function") return token.object.getCenter();
+    }
+    return null;
+}
+
+/**
+ * Measure grid distance between tokens.
+ * @param {Token} origin
+ * @param {Token} target
+ * @returns {number}
+ */
+export function measureTokenDistance(origin, target) {
+    const grid = canvas?.grid;
+    if (!grid || !origin || !target) return Number.POSITIVE_INFINITY;
+    const originCenter = getTokenCenter(origin);
+    const targetCenter = getTokenCenter(target);
+    if (!originCenter || !targetCenter) return Number.POSITIVE_INFINITY;
+    const distance = grid.measureDistance(originCenter, targetCenter);
+    return Number.isFinite(distance) ? distance : Number.POSITIVE_INFINITY;
+}
+
+/**
+ * Determine whether the provided actor is a player character.
+ * @param {Actor} actor
+ * @returns {boolean}
+ */
+export function isPC(actor) {
+    return actor?.type === "acolyte";
+}
+
+/**
+ * Select the nearest opposing actor token based on actor type.
+ * PCs target nearest NPC, NPCs target nearest PC.
+ * @param {Token|null} originToken
+ * @param {Actor|null} originActor
+ * @returns {Token|null}
+ */
+export function findNearestOpposition(originToken, originActor) {
+    const tokens = canvas?.tokens?.placeables ?? [];
+    if (!tokens.length) return null;
+
+    const desiredType = isPC(originActor) ? "npc" : "acolyte";
+    const candidates = tokens.filter(token => token?.actor?.type === desiredType);
+    if (!candidates.length) return null;
+
+    if (!originToken) return candidates[0] ?? null;
+
+    let closest = null;
+    let closestDistance = Number.POSITIVE_INFINITY;
+    for (const token of candidates) {
+        const distance = measureTokenDistance(originToken, token);
+        if (distance < closestDistance) {
+            closest = token;
+            closestDistance = distance;
+        }
+    }
+    return closest;
+}
+
+/**
+ * Returns a sorted list of target tokens. Defaults to user targets, otherwise nearest opposition.
+ * @param {Token|null} originToken
+ * @param {Actor|null} originActor
+ * @returns {Token[]}
+ */
+export function resolveInitialTargets(originToken, originActor) {
+    const explicitTargets = Array.from(game.user?.targets ?? []).filter(token => token?.actor);
+    if (explicitTargets.length) return explicitTargets;
+    const nearest = findNearestOpposition(originToken, originActor);
+    return nearest ? [nearest] : [];
+}
+
+/**
+ * Normalize a weapon range value into a numeric distance.
+ * @param {number|string|object} rangeValue
+ * @returns {number}
+ */
+export function normalizeRange(rangeValue) {
+    if (rangeValue === null || typeof rangeValue === "undefined") return NaN;
+    if (typeof rangeValue === "number") return rangeValue;
+    if (typeof rangeValue === "object") {
+        const nested = rangeValue.value ?? rangeValue.max ?? rangeValue.min;
+        if (typeof nested !== "undefined") {
+            const numeric = Number(nested);
+            if (!Number.isNaN(numeric)) return numeric;
+        }
+    }
+    const numeric = Number(rangeValue);
+    if (!Number.isNaN(numeric)) return numeric;
+    const match = String(rangeValue).match(/[-+]?[0-9]*\.?[0-9]+/);
+    return match ? Number(match[0]) : NaN;
+}
+
+/**
+ * Compute a range modifier using DH2e bands.
+ * @param {number} distance
+ * @param {number} weaponRange
+ * @returns {{modifier:number, band:string}|null}
+ */
+export function computeRangeModifier(distance, weaponRange) {
+    if (!Number.isFinite(distance) || !Number.isFinite(weaponRange) || weaponRange <= 0) return null;
+
+    const pointBlankLimit = 3;
+    const shortLimit = weaponRange / 2;
+    const standardLimit = weaponRange;
+    const longLimit = weaponRange * 2;
+    const extremeLimit = weaponRange * 3;
+
+    if (distance <= pointBlankLimit) return { modifier: 30, band: "Point Blank" };
+    if (distance <= shortLimit) return { modifier: 10, band: "Short" };
+    if (distance <= standardLimit) return { modifier: 0, band: "Standard" };
+    if (distance <= longLimit) return { modifier: -10, band: "Long" };
+    if (distance <= extremeLimit) return { modifier: -30, band: "Extreme" };
+    return null;
+}
+
+/**
+ * Resolve measured distances and automatic range modifiers for targets.
+ * @param {Token|null} originToken
+ * @param {Token[]} targets
+ * @param {number|string|object} weaponRange
+ * @returns {{summary: string, modifier: number, perTarget: Array<{token: Token, distance: number, range: {modifier:number, band:string}|null}>}}
+ */
+export function resolveRangeData(originToken, targets, weaponRange) {
+    const numericRange = normalizeRange(weaponRange);
+    const perTarget = (targets ?? []).map(token => {
+        const distance = originToken ? measureTokenDistance(originToken, token) : NaN;
+        const range = Number.isFinite(numericRange) ? computeRangeModifier(distance, numericRange) : null;
+        return { token, distance, range };
+    });
+
+    const modifiers = perTarget
+        .map(entry => entry.range?.modifier)
+        .filter(mod => Number.isFinite(mod));
+
+    const modifier = modifiers.length ? Math.min(...modifiers) : 0;
+    const parts = perTarget.map(entry => {
+        if (!Number.isFinite(entry.distance)) return `${entry.token.name}: ?`;
+        const band = entry.range ? `${entry.range.band} (${entry.range.modifier >= 0 ? "+" : ""}${entry.range.modifier})` : "Out of range";
+        return `${entry.token.name}: ${entry.distance.toFixed(1)}m ${band}`;
+    });
+
+    return {
+        summary: parts.join(" • "),
+        modifier,
+        perTarget
+    };
+}
+
+/**
+ * Retrieve weapons from an actor filtered by attack mode.
+ * @param {Actor} actor
+ * @param {"melee"|"ranged"|"any"} mode
+ * @returns {Item[]}
+ */
+export function getWeaponsForMode(actor, mode) {
+    const weapons = actor?.items?.filter(item => item?.type === "weapon") ?? [];
+    if (mode === "any") return weapons;
+
+    return weapons.filter(weapon => {
+        const weaponClass = weapon.system?.class ?? weapon.class;
+        if (mode === "melee") return MELEE_CLASSES.has(weaponClass);
+        if (mode === "ranged") return weaponClass !== "melee" || RANGED_CLASSES.has(weaponClass);
+        return true;
+    });
+}
+
+/**
+ * Choose a weapon by id, or optionally select one at random.
+ * @param {Actor} actor
+ * @param {Item[]} weapons
+ * @param {string} weaponId
+ * @param {boolean} randomWeapon
+ * @returns {Item|null}
+ */
+export function resolveWeaponSelection(actor, weapons, weaponId, randomWeapon) {
+    if (!actor || !weapons?.length) return null;
+    if (randomWeapon) {
+        const index = Math.floor(Math.random() * weapons.length);
+        return weapons[index] ?? null;
+    }
+    return weapons.find(weapon => weapon.id === weaponId) ?? weapons[0] ?? null;
+}
+
+/**
+ * Extract a numeric trait value, e.g. Blast (3).
+ * @param {string} special
+ * @param {RegExp} regex
+ * @returns {number|null}
+ */
+export function extractNumericTrait(special, regex) {
+    if (!special) return null;
+    const match = special.match(regex);
+    if (!match) return null;
+    const valueMatch = match[0].match(/\d+/);
+    if (!valueMatch) return null;
+    const value = Number(valueMatch[0]);
+    return Number.isFinite(value) ? value : null;
+}
+
+/**
+ * Place a blast template and return tokens inside it.
+ * @param {Token|null} originToken
+ * @param {Item|null} weapon
+ * @returns {Promise<{template: MeasuredTemplateDocument|null, targets: Token[]}>}
+ */
+export async function placeBlastTemplate(originToken, weapon) {
+    const blastValue = extractNumericTrait(weapon?.system?.special ?? weapon?.special ?? "", /Blast\s*\((\d+)\)/i);
+    if (!blastValue || !originToken) return { template: null, targets: [] };
+
+    const templateData = {
+        t: "circle",
+        user: game.user.id,
+        distance: blastValue,
+        direction: 0,
+        x: originToken.center?.x ?? originToken.x,
+        y: originToken.center?.y ?? originToken.y,
+        fillColor: game.user.color,
+        flags: { "dark-heresy": { origin: originToken.document?.uuid } }
+    };
+
+    const cls = CONFIG.MeasuredTemplate.documentClass;
+    const templateDoc = new cls(templateData, { parent: canvas.scene });
+    const templateObject = new MeasuredTemplate(templateDoc);
+    await templateObject.drawPreview();
+
+    const placedDoc = templateObject.document ?? null;
+    const targets = placedDoc ? collectTokensInTemplate(placedDoc) : [];
+    if (targets.length) {
+        const ids = targets.map(token => token.id);
+        game.user.updateTokenTargets(ids);
+    }
+    return { template: placedDoc, targets };
+}
+
+/**
+ * Place a spray cone template and return tokens inside it.
+ * @param {Token|null} originToken
+ * @param {Item|null} weapon
+ * @returns {Promise<{template: MeasuredTemplateDocument|null, targets: Token[]}>}
+ */
+export async function placeSprayTemplate(originToken, weapon) {
+    if (!originToken || !weapon) return { template: null, targets: [] };
+    const rollData = DarkHeresyUtil.createWeaponRollData(originToken.actor, weapon);
+    const template = PlaceableTemplate.cone({ item: weapon.id, actor: originToken.actor.id }, 30, rollData.weapon.range);
+    const placed = await template.drawPreview();
+    const placedDoc = placed?.document ?? placed ?? null;
+    const targets = placedDoc ? collectTokensInTemplate(placedDoc) : [];
+    if (targets.length) {
+        const ids = targets.map(token => token.id);
+        game.user.updateTokenTargets(ids);
+    }
+    return { template: placedDoc, targets };
+}
+
+/**
+ * Collect tokens whose centers fall within a measured template.
+ * @param {MeasuredTemplateDocument} templateDoc
+ * @returns {Token[]}
+ */
+export function collectTokensInTemplate(templateDoc) {
+    const templateObject = templateDoc?.object;
+    if (!templateObject) return [];
+    const tokens = canvas?.tokens?.placeables ?? [];
+    const contained = tokens.filter(token => {
+        const center = getTokenCenter(token);
+        if (!center) return false;
+        return templateObject.shape?.contains?.(center.x - templateObject.x, center.y - templateObject.y);
+    });
+    return contained;
+}
+
+/**
+ * Map a d100 result to a hit location using the requested table.
+ * @param {number} rollResult
+ * @returns {{key:string, armour:string, label:string, target:number}}
+ */
+export function getHitLocationFromRoll(rollResult) {
+    const padded = rollResult < 10 ? `0${rollResult}` : `${rollResult}`;
+    const reversed = Number(padded.split("").reverse().join(""));
+    return mapLocationFromTarget(reversed);
+}
+
+/**
+ * Map a numeric location target to a hit location entry.
+ * @param {number} locationTarget
+ * @returns {{key:string, armour:string, label:string, target:number}}
+ */
+export function mapLocationFromTarget(locationTarget) {
+    const target = Math.min(Math.max(Number(locationTarget) || 0, 1), 100);
+    const entry = HIT_LOCATION_TABLE.find(part => target <= part.max) ?? HIT_LOCATION_TABLE.at(-1);
+    return {
+        key: entry.key,
+        armour: entry.armour,
+        label: entry.label,
+        target
+    };
+}
+
+/**
+ * Roll a random hit location.
+ * @returns {{key:string, armour:string, label:string, target:number, roll:number}}
+ */
+export async function rollRandomLocation() {
+    const roll = await new Roll("1d100").evaluate({ async: true });
+    const location = mapLocationFromTarget(roll.total);
+    return {
+        ...location,
+        roll: roll.total
+    };
+}
+
+/**
+ * Spend a fate point on an actor if possible.
+ * @param {Actor} actor
+ * @returns {Promise<boolean>}
+ */
+export async function spendFate(actor) {
+    const current = Number(actor?.fate?.value ?? actor?.system?.fate?.value ?? 0);
+    if (!actor || current <= 0) return false;
+    await actor.update({ "system.fate.value": current - 1 });
+    return true;
+}
+
+/**
+ * Ensure the Deny the Witch talent exists in the world item directory.
+ * @returns {Promise<Item|null>}
+ */
+export async function ensureDenyTheWitchTalent() {
+    let talent = game.items?.find(item => item.name === DENY_THE_WITCH_NAME && item.type === "talent");
+    if (talent) return talent;
+
+    talent = await Item.create({
+        name: DENY_THE_WITCH_NAME,
+        type: "talent",
+        img: "icons/magic/defensive/shield-barrier-flaming-diamond-blue.webp",
+        system: {
+            prerequisites: "",
+            aptitudes: "Willpower, Defence",
+            benefit: "You may attempt to resist psychic powers with a Willpower test as a Reaction.",
+            tier: 2,
+            starter: true,
+            cost: 0
+        },
+        ownership: buildMacroOwnership()
+    }, { displaySheet: false });
+
+    ui.notifications.info("Created base talent: Deny the Witch");
+    return talent;
+}
+
+/**
+ * Determine whether an actor has the Deny the Witch talent.
+ * @param {Actor} actor
+ * @returns {boolean}
+ */
+export function actorHasDenyTheWitch(actor) {
+    if (!actor) return false;
+    return actor.items?.some(item => item.type === "talent" && item.name === DENY_THE_WITCH_NAME) ?? false;
+}
+
+/**
+ * Build macro ownership so everyone can execute but only GMs can edit.
+ * @returns {object}
+ */
+export function buildMacroOwnership() {
+    const ownership = { default: CONST.DOCUMENT_OWNERSHIP_LEVELS.OBSERVER };
+    for (const user of game.users ?? []) {
+        if (user.isGM) {
+            ownership[user.id] = CONST.DOCUMENT_OWNERSHIP_LEVELS.OWNER;
+        }
+    }
+    return ownership;
+}
+
+/**
+ * Ensure the actor has a dedicated additive armour item for cover.
+ * @param {Actor} actor
+ * @returns {Promise<Item|null>}
+ */
+export async function ensureCoverItem(actor) {
+    if (!actor) return null;
+    let coverItem = actor.items.find(item => item.type === "armour" && item.name === COVER_ITEM_NAME);
+    if (coverItem) return coverItem;
+
+    coverItem = await actor.createEmbeddedDocuments("Item", [{
+        name: COVER_ITEM_NAME,
+        type: "armour",
+        img: "icons/environment/settlement/stone-wall.webp",
+        system: {
+            type: "basic",
+            isAdditive: true,
+            part: {
+                head: 0,
+                leftArm: 0,
+                rightArm: 0,
+                body: 0,
+                leftLeg: 0,
+                rightLeg: 0
+            },
+            maxAgility: 0
+        },
+        flags: {
+            "dark-heresy": {
+                coverLevelIndex: 0,
+                coverLevelValue: 0
+            }
+        }
+    }]);
+
+    return coverItem?.[0] ?? null;
+}
+
+/**
+ * Apply cover values to the actor's cover item.
+ * @param {Actor} actor
+ * @param {Record<string, number>} partValues
+ * @param {number} levelIndex
+ * @returns {Promise<Item|null>}
+ */
+export async function applyCoverValues(actor, partValues, levelIndex) {
+    const coverItem = await ensureCoverItem(actor);
+    if (!coverItem) return null;
+
+    const levelValue = COVER_LEVELS[levelIndex] ?? 0;
+    await coverItem.update({
+        "system.isAdditive": true,
+        "system.part": {
+            head: Number(partValues.head ?? 0),
+            leftArm: Number(partValues.leftArm ?? 0),
+            rightArm: Number(partValues.rightArm ?? 0),
+            body: Number(partValues.body ?? 0),
+            leftLeg: Number(partValues.leftLeg ?? 0),
+            rightLeg: Number(partValues.rightLeg ?? 0)
+        },
+        "flags.dark-heresy.coverLevelIndex": levelIndex,
+        "flags.dark-heresy.coverLevelValue": levelValue
+    });
+    return coverItem;
+}
+
+/**
+ * Reduce cover by one level when it is penetrated.
+ * @param {Actor} actor
+ * @param {string} locationKey
+ * @returns {Promise<{reduced: boolean, newLevelIndex:number, newLevelValue:number}>}
+ */
+export async function reduceCoverLevel(actor, locationKey) {
+    const coverItem = await ensureCoverItem(actor);
+    if (!coverItem) {
+        return { reduced: false, newLevelIndex: 0, newLevelValue: 0 };
+    }
+
+    const currentIndex = Number(coverItem.getFlag("dark-heresy", "coverLevelIndex") ?? 0);
+    const newLevelIndex = Math.max(currentIndex - 1, 0);
+    const newLevelValue = COVER_LEVELS[newLevelIndex] ?? 0;
+
+    const currentParts = foundry.utils.duplicate(coverItem.system.part);
+    for (const key of Object.keys(currentParts)) {
+        if (currentParts[key] > 0) currentParts[key] = newLevelValue;
+    }
+
+    await coverItem.update({
+        "system.part": currentParts,
+        "flags.dark-heresy.coverLevelIndex": newLevelIndex,
+        "flags.dark-heresy.coverLevelValue": newLevelValue
+    });
+
+    return {
+        reduced: newLevelIndex !== currentIndex,
+        newLevelIndex,
+        newLevelValue,
+        locationKey
+    };
+}
+
+/**
+ * Retrieve the cover value for a given location.
+ * @param {Actor} actor
+ * @param {string} locationKey
+ * @returns {number}
+ */
+export function getCoverValue(actor, locationKey) {
+    const coverItem = actor?.items?.find(item => item.type === "armour" && item.name === COVER_ITEM_NAME);
+    if (!coverItem) return 0;
+    return Number(coverItem.system?.part?.[locationKey] ?? 0);
+}
+
+/**
+ * Create roll data for a weapon including stat lookups and helper references.
+ * @param {Actor} actor
+ * @param {Item} weapon
+ * @returns {object}
+ */
+export function buildWeaponRollData(actor, weapon) {
+    const rollData = DarkHeresyUtil.createWeaponRollData(actor, weapon);
+    rollData.helpers = {
+        characteristics: buildCharacteristicLookup(actor)
+    };
+    return rollData;
+}

--- a/script/macro/attack-windows/cover/index.js
+++ b/script/macro/attack-windows/cover/index.js
@@ -1,0 +1,164 @@
+import {
+    COVER_LEVELS,
+    applyCoverValues,
+    buildCharacteristicLookup,
+    ensureCoverItem,
+    resolveActorContext
+} from "../common.js";
+
+const LOCATION_LABELS = Object.freeze({
+    head: "Head",
+    leftArm: "Left Arm",
+    rightArm: "Right Arm",
+    body: "Torso",
+    leftLeg: "Left Leg",
+    rightLeg: "Right Leg"
+});
+
+/**
+ *
+ * @param defaultLevel
+ */
+function buildLevelOptions(defaultLevel) {
+    return COVER_LEVELS
+        .map((value, index) => `<option value="${index}" ${value === defaultLevel ? "selected" : ""}>${value}</option>`)
+        .join("");
+}
+
+/**
+ *
+ * @param defaultValue
+ */
+function buildLocationFields(defaultValue) {
+    return Object.entries(LOCATION_LABELS)
+        .map(([key, label]) => `
+        <div class="form-group">
+            <label>${label}</label>
+            <input type="number" name="loc-${key}" value="${defaultValue}" />
+            <label><input type="checkbox" name="use-${key}" checked /> Apply</label>
+        </div>`)
+        .join("");
+}
+
+/**
+ *
+ * @param actor
+ * @param defaultLevel
+ */
+function buildDialogContent(actor, defaultLevel) {
+    const levelOptions = buildLevelOptions(defaultLevel);
+    const locationFields = buildLocationFields(defaultLevel);
+    const stats = buildCharacteristicLookup(actor);
+    return `
+    <form class="dh-cover-window">
+        <div class="form-group">
+            <label>Actor</label>
+            <div>${actor.name}</div>
+        </div>
+        <div class="form-group">
+            <label>Cover Level</label>
+            <select name="coverLevel">${levelOptions}</select>
+        </div>
+        <div class="form-group">
+            <label>Base Armour Value</label>
+            <input type="number" name="baseValue" value="${defaultLevel}" />
+        </div>
+        <fieldset>
+            <legend>Locations</legend>
+            ${locationFields}
+        </fieldset>
+        <p class="notes">Cover defaults to legs + torso. Adjust locations as needed. Cover will degrade by one level when penetrated.</p>
+        <p class="notes">Stats: WP ${stats.willpower.total} • Fel ${stats.fellowship.total}</p>
+    </form>`;
+}
+
+/**
+ *
+ * @param html
+ * @param baseValue
+ */
+function buildPartValues(html, baseValue) {
+    const partValues = {};
+    for (const key of Object.keys(LOCATION_LABELS)) {
+        const enabled = html.find(`[name='use-${key}']`).is(":checked");
+        const value = Number(html.find(`[name='loc-${key}']`).val() || baseValue);
+        partValues[key] = enabled ? value : 0;
+    }
+    return partValues;
+}
+
+/**
+ *
+ * @param partValues
+ */
+function summarizeParts(partValues) {
+    return Object.entries(partValues)
+        .map(([key, value]) => `${LOCATION_LABELS[key]} ${value}`)
+        .join(" • ");
+}
+
+/**
+ *
+ * @param actor
+ * @param partValues
+ * @param levelValue
+ */
+async function sendCoverToChat(actor, partValues, levelValue) {
+    const summary = summarizeParts(partValues);
+    const content = `
+    <div class="dh-cover-card">
+        <div><strong>${actor.name}</strong> applies cover.</div>
+        <div>Level: ${levelValue}</div>
+        <div>${summary}</div>
+        <div class="notes">Cover loses one level when penetrated.</div>
+    </div>`;
+
+    await ChatMessage.create({
+        content,
+        speaker: ChatMessage.getSpeaker({ actor })
+    });
+}
+
+/**
+ *
+ */
+export async function runApplyCoverDialog() {
+    const { actor } = resolveActorContext();
+    if (!actor) {
+        ui.notifications.warn("No actor available for cover.");
+        return;
+    }
+
+    const defaultLevel = COVER_LEVELS[1];
+    await ensureCoverItem(actor);
+
+    const result = await new Promise(resolve => {
+        const content = buildDialogContent(actor, defaultLevel);
+        new Dialog({
+            title: "Apply Cover",
+            content,
+            buttons: {
+                apply: {
+                    label: "Apply Cover",
+                    callback: html => {
+                        const levelIndex = Number(html.find("[name='coverLevel']").val() || 0);
+                        const baseValue = Number(html.find("[name='baseValue']").val() || COVER_LEVELS[levelIndex] || 0);
+                        const partValues = buildPartValues(html, baseValue);
+                        resolve({ levelIndex, baseValue, partValues });
+                    }
+                },
+                cancel: {
+                    label: "Cancel",
+                    callback: () => resolve(null)
+                }
+            },
+            default: "apply"
+        }).render(true);
+    });
+
+    if (!result) return;
+
+    const levelValue = COVER_LEVELS[result.levelIndex] ?? result.baseValue;
+    await applyCoverValues(actor, result.partValues, result.levelIndex);
+    await sendCoverToChat(actor, result.partValues, levelValue);
+}

--- a/script/macro/attack-windows/dialogs/attack-dialog.js
+++ b/script/macro/attack-windows/dialogs/attack-dialog.js
@@ -1,0 +1,1179 @@
+import DarkHeresyUtil from "../../../common/util.js";
+import {
+    actorHasDenyTheWitch,
+    buildWeaponRollData,
+    computeRangeModifier,
+    extractNumericTrait,
+    getCoverValue,
+    getHitLocationFromRoll,
+    reduceCoverLevel,
+    resolveActorContext,
+    resolveInitialTargets,
+    resolveRangeData,
+    resolveWeaponSelection,
+    rollRandomLocation,
+    spendFate
+} from "../common.js";
+
+const ATTACK_TYPE_CONFIG = Object.freeze({
+    standard: { label: "Standard Attack", modifier: 10, hitMargin: 1, maxHits: 1 },
+    semi_auto: { label: "Semi Auto", modifier: 0, hitMargin: 2, maxHitsKey: "burst" },
+    full_auto: { label: "Full Auto", modifier: -10, hitMargin: 1, maxHitsKey: "full" },
+    called_shot: { label: "Called Shot", modifier: -20, hitMargin: 1, maxHits: 1 },
+    charge: { label: "Charge", modifier: 20, hitMargin: 1, maxHits: 1 },
+    swift: { label: "Swift Attack", modifier: 0, hitMargin: 2, maxHitsKey: "melee" },
+    lightning: { label: "Lightning Attack", modifier: -10, hitMargin: 1, maxHitsKey: "melee" },
+    allOut: { label: "All Out Attack", modifier: 30, hitMargin: 1, maxHits: 1 }
+});
+
+const AIM_CONFIG = Object.freeze({
+    none: { label: "No Aim", modifier: 0 },
+    half: { label: "Half Aim (+10)", modifier: 10 },
+    full: { label: "Full Aim (+20)", modifier: 20 }
+});
+
+/**
+ *
+ * @param modifier
+ */
+function clampModifier(modifier) {
+    if (modifier > 60) return 60;
+    if (modifier < -60) return -60;
+    return modifier;
+}
+
+/**
+ *
+ * @param value
+ */
+function formatSigned(value) {
+    const numeric = Number(value) || 0;
+    return `${numeric >= 0 ? "+" : ""}${numeric}`;
+}
+
+/**
+ *
+ * @param formula
+ * @param actor
+ * @param psyValue
+ */
+function replaceSymbols(formula, actor, psyValue = null) {
+    if (!formula) return "0";
+    let updated = `${formula}`;
+    if (psyValue !== null && psyValue !== undefined) {
+        updated = updated.replaceAll(/PR/gi, psyValue);
+    }
+    const boni = actor?.attributeBoni ?? [];
+    for (const bonus of boni) {
+        updated = updated.replaceAll(bonus.regex, bonus.value);
+    }
+    return updated;
+}
+
+/**
+ *
+ * @param roll
+ */
+function extractDiceTerms(roll) {
+    const diceTerms = [];
+    for (const term of roll.terms ?? []) {
+        if (term?.faces) {
+            for (const result of term.results ?? []) {
+                diceTerms.push({
+                    faces: term.faces,
+                    result,
+                    term
+                });
+            }
+        }
+    }
+    return diceTerms;
+}
+
+/**
+ *
+ * @param diceTerms
+ * @param minimum
+ */
+function applyMinimumDice(diceTerms, minimum) {
+    if (!Number.isFinite(minimum) || minimum <= 0) return null;
+    const candidates = diceTerms.filter(entry => entry.result?.active !== false);
+    if (!candidates.length) return null;
+    candidates.sort((a, b) => (a.result.result ?? 0) - (b.result.result ?? 0));
+    const chosen = candidates[0];
+    const original = chosen.result.result ?? 0;
+    if (original >= minimum) return null;
+    chosen.result.result = minimum;
+    return { original, minimum };
+}
+
+/**
+ *
+ * @param diceTerms
+ * @param provenValue
+ */
+function applyProven(diceTerms, provenValue) {
+    if (!Number.isFinite(provenValue) || provenValue <= 0) return [];
+    const updates = [];
+    for (const entry of diceTerms) {
+        if (entry.result?.active === false) continue;
+        const original = entry.result.result ?? 0;
+        if (original < provenValue) {
+            entry.result.result = provenValue;
+            updates.push({ original, updated: provenValue });
+        }
+    }
+    return updates;
+}
+
+/**
+ *
+ * @param formula
+ */
+async function rollDamageFormula(formula) {
+    const roll = await new Roll(formula).evaluate({ async: true });
+    return roll;
+}
+
+/**
+ *
+ */
+async function rollRighteousFury() {
+    const rfRoll = await new Roll("1d5").evaluate({ async: true });
+    return rfRoll.total;
+}
+
+/**
+ *
+ * @param mode
+ */
+function getAttackTypeOptions(mode) {
+    if (mode === "melee") {
+        return ["standard", "charge", "swift", "lightning", "allOut", "called_shot"];
+    }
+    return ["standard", "semi_auto", "full_auto", "called_shot"];
+}
+
+/**
+ *
+ * @param mode
+ */
+function getDefaultAttackType(mode) {
+    return mode === "melee" ? "standard" : "standard";
+}
+
+/**
+ *
+ * @param weapon
+ * @param rollData
+ */
+function parseTraits(weapon, rollData) {
+    const traits = foundry.utils.duplicate(rollData.weapon.traits ?? {});
+    const special = weapon.system?.special ?? weapon.special ?? "";
+    traits.blast = extractNumericTrait(special, /Blast\s*\((\d+)\)/i);
+    traits.spray = traits.spray || /Spray/i.test(special);
+    traits.proven = traits.proven ?? extractNumericTrait(special, /Proven\s*\((\d+)\)/i);
+    traits.tearing = traits.tearing || /Tearing/i.test(special);
+    traits.razorSharp = traits.razorSharp || /Razor/i.test(special);
+    traits.accurate = traits.accurate || /Accurate/i.test(special);
+    traits.storm = traits.storm || /Storm/i.test(special);
+    traits.twinLinked = traits.twinLinked || /Twin/i.test(special);
+    traits.force = traits.force || /Force/i.test(special);
+    traits.inaccurate = traits.inaccurate || /Inaccurate/i.test(special);
+    return traits;
+}
+
+/**
+ *
+ * @param configKey
+ * @param rollData
+ * @param mode
+ */
+function determineAttackType(configKey, rollData, mode) {
+    const config = ATTACK_TYPE_CONFIG[configKey] ?? ATTACK_TYPE_CONFIG.standard;
+    const meleeBonus = rollData.helpers?.characteristics?.weaponSkill?.bonus ?? rollData.helpers?.characteristics?.ballisticSkill?.bonus ?? 1;
+    const maxHits = config.maxHits
+        ?? (config.maxHitsKey === "burst" ? rollData.weapon.rateOfFire?.burst ?? 1 : null)
+        ?? (config.maxHitsKey === "full" ? rollData.weapon.rateOfFire?.full ?? 1 : null)
+        ?? (config.maxHitsKey === "melee" ? meleeBonus : 1);
+
+    const label = config.label;
+    const modifier = config.modifier + (mode === "ranged" && configKey === "standard" ? 0 : 0);
+    return {
+        key: configKey,
+        label,
+        modifier,
+        hitMargin: config.hitMargin,
+        maxHits: Math.max(Number(maxHits) || 1, 1)
+    };
+}
+
+/**
+ *
+ * @param dos
+ * @param attackType
+ * @param traits
+ */
+function computeHitsOnSuccess(dos, attackType, traits) {
+    const margin = Math.max(attackType.hitMargin || 1, 1);
+    const baseHits = 1 + Math.floor(Math.max(dos - 1, 0) / margin);
+    let hits = Math.min(baseHits, attackType.maxHits);
+
+    if (traits?.storm) hits *= 2;
+    return Math.max(hits, 1);
+}
+
+/**
+ *
+ * @param targetNumber
+ * @param options
+ */
+async function rollAttack(targetNumber, options = {}) {
+    const roll = await new Roll("1d100").evaluate({ async: true });
+    const result = roll.total;
+    const success = result <= targetNumber;
+    const degrees = success
+        ? 1 + Math.floor(targetNumber / 10) - Math.floor(result / 10)
+        : 1 + Math.floor(result / 10) - Math.floor(targetNumber / 10);
+    return {
+        roll,
+        result,
+        success,
+        dos: success ? degrees : 0,
+        dof: success ? 0 : degrees
+    };
+}
+
+/**
+ *
+ * @param actor
+ */
+function getTargetTypeLabel(actor) {
+    return actor?.type === "npc" ? "NPC" : "PC";
+}
+
+/**
+ *
+ * @param weapon
+ */
+function getWeaponClass(weapon) {
+    return weapon.system?.class ?? weapon.class ?? "";
+}
+
+/**
+ *
+ * @param weaponClass
+ */
+function canParry(weaponClass) {
+    return weaponClass === "melee" || weaponClass === "pistol";
+}
+
+/**
+ *
+ * @param token
+ * @param defenceType
+ * @param weaponClass
+ */
+function actorCanDefend(token, defenceType, weaponClass) {
+    if (!token?.actor) return { allowed: false, reason: "No actor" };
+    const stunned = token.document?.hasStatusEffect?.("stunned") || token.document?.hasStatusEffect?.("unconscious");
+    if (stunned) return { allowed: false, reason: "Cannot defend while stunned" };
+    if (defenceType === "parry" && !canParry(weaponClass)) return { allowed: false, reason: "Weapon cannot be parried" };
+    if (defenceType === "deny" && !actorHasDenyTheWitch(token.actor)) return { allowed: false, reason: "No Deny the Witch talent" };
+    return { allowed: true, reason: "" };
+}
+
+/**
+ *
+ * @param actor
+ * @param defenceType
+ */
+function buildDefenceRollData(actor, defenceType) {
+    if (defenceType === "dodge") {
+        return DarkHeresyUtil.createSkillRollData(actor, "dodge");
+    }
+    if (defenceType === "parry") {
+        const data = DarkHeresyUtil.createSkillRollData(actor, "parry");
+        data.target.modifier = (data.target.modifier ?? 0) + 10;
+        return data;
+    }
+    const denyData = DarkHeresyUtil.createCharacteristicRollData(actor, "willpower");
+    denyData.target.modifier = (denyData.target.modifier ?? 0);
+    return denyData;
+}
+
+/**
+ *
+ * @param token
+ * @param defenceType
+ * @param weaponClass
+ */
+async function resolveDefenceRoll(token, defenceType, weaponClass) {
+    const defenceCheck = actorCanDefend(token, defenceType, weaponClass);
+    if (!defenceCheck.allowed) {
+        return {
+            attempted: false,
+            defenceType,
+            success: false,
+            reason: defenceCheck.reason
+        };
+    }
+
+    const rollData = buildDefenceRollData(token.actor, defenceType);
+    const targetNumber = clampModifier((rollData.target?.base ?? 0) + (rollData.target?.modifier ?? 0));
+    const roll = await rollAttack(targetNumber);
+
+    return {
+        attempted: true,
+        defenceType,
+        success: roll.success,
+        targetNumber,
+        roll
+    };
+}
+
+/**
+ *
+ * @param token
+ * @param weaponClass
+ * @param attackLabel
+ */
+async function promptDefence(token, weaponClass, attackLabel) {
+    const options = [
+        { key: "accept", label: "Accept Hit" },
+        { key: "dodge", label: "Defend: Dodge" },
+        { key: "parry", label: "Defend: Parry (+10)" },
+        { key: "deny", label: "Defend: Deny the Witch" }
+    ];
+
+    return new Promise(resolve => {
+        const content = `
+        <form>
+            <div class="form-group">
+                <label>${token.name} response to ${attackLabel}</label>
+                <select name="defence">
+                    ${options.map(option => `<option value="${option.key}">${option.label}</option>`).join("")}
+                </select>
+            </div>
+            <p class="notes">Parry is only available against melee/pistol attacks. Deny the Witch requires the talent.</p>
+        </form>`;
+
+        new Dialog({
+            title: `${token.name} Defence`,
+            content,
+            buttons: {
+                confirm: {
+                    label: "Resolve",
+                    callback: html => {
+                        const defenceType = html.find("[name='defence']").val();
+                        resolve(defenceType);
+                    }
+                },
+                accept: {
+                    label: "Accept Hit",
+                    callback: () => resolve("accept")
+                }
+            },
+            default: "confirm"
+        }).render(true);
+    });
+}
+
+/**
+ *
+ * @param sections
+ */
+function buildTabsContent(sections) {
+    const nav = sections
+        .map((section, index) => `<a class="item ${index === 0 ? "active" : ""}" data-tab="${section.id}">${section.label}</a>`)
+        .join("");
+    const body = sections
+        .map((section, index) => `
+            <div class="tab ${index === 0 ? "active" : ""}" data-tab="${section.id}">
+                ${section.content}
+            </div>`)
+        .join("");
+    return `
+    <div class="dh-tabs">
+        <nav class="tabs" data-group="dh-attack-tabs">${nav}</nav>
+        <section class="tab-content">${body}</section>
+    </div>`;
+}
+
+/**
+ *
+ * @param html
+ */
+function activateTabs(html) {
+    const tabs = html.find(".dh-tabs nav .item");
+    tabs.on("click", ev => {
+        ev.preventDefault();
+        const tab = ev.currentTarget.dataset.tab;
+        tabs.removeClass("active");
+        html.find(`.dh-tabs nav .item[data-tab='${tab}']`).addClass("active");
+        html.find(".dh-tabs .tab").removeClass("active");
+        html.find(`.dh-tabs .tab[data-tab='${tab}']`).addClass("active");
+    });
+}
+
+/**
+ *
+ * @param weapons
+ */
+function buildWeaponOptions(weapons) {
+    if (!weapons.length) {
+        return "<option value=\"\">No weapons found</option>";
+    }
+    return weapons
+        .map(weapon => {
+            const weaponClass = getWeaponClass(weapon);
+            const range = weapon.system?.range ?? weapon.range ?? 0;
+            const damage = weapon.system?.damage ?? weapon.damage ?? "";
+            return `<option value="${weapon.id}">${weapon.name} (${weaponClass}, ${range}m, ${damage})</option>`;
+        })
+        .join("");
+}
+
+/**
+ *
+ * @param traits
+ */
+function getAoEFlags(traits) {
+    return {
+        blast: Number.isFinite(Number(traits?.blast)) && Number(traits.blast) > 0,
+        spray: !!traits?.spray
+    };
+}
+
+/**
+ *
+ * @param root0
+ * @param root0.formula
+ * @param root0.traits
+ * @param root0.dos
+ * @param root0.penetration
+ */
+async function buildDamageRoll({ formula, traits, dos, penetration }) {
+    const roll = await rollDamageFormula(formula);
+    const diceTerms = extractDiceTerms(roll);
+    const provenUpdates = applyProven(diceTerms, traits.proven);
+    const minDieValue = dos;
+    const minimumUpdate = applyMinimumDice(diceTerms, Math.max(minDieValue, traits.proven ?? 0));
+    const adjustedTotal = roll._evaluateTotal();
+
+    let righteousFury = 0;
+    const rfFace = traits.rfFace ?? 10;
+    for (const entry of diceTerms) {
+        if (entry.result?.active === false) continue;
+        if ((entry.result.result ?? 0) >= rfFace) {
+            righteousFury = await rollRighteousFury();
+            break;
+        }
+    }
+
+    return {
+        total: adjustedTotal,
+        righteousFury,
+        penetration,
+        dos,
+        roll,
+        provenUpdates,
+        minimumUpdate
+    };
+}
+
+/**
+ *
+ * @param actor
+ * @param rollData
+ * @param traits
+ * @param psyValue
+ */
+function buildDamageFormula(actor, rollData, traits, psyValue = null) {
+    let formula = rollData.weapon.damageFormula ?? rollData.weapon.damage ?? "0";
+    formula = replaceSymbols(formula, actor, psyValue);
+    if (traits.tearing) {
+        formula = formula.replace(/(\d+)d(\d+)/i, (match, dice, faces) => `${dice + 1}d${faces}dl1`);
+    }
+    formula = `${formula}+${rollData.weapon.damageBonus ?? 0}`;
+    return formula;
+}
+
+/**
+ *
+ * @param actor
+ * @param rollData
+ * @param psyValue
+ */
+function buildPenetrationFormula(actor, rollData, psyValue = null) {
+    const penetrationFormula = rollData.weapon.penetrationFormula ?? rollData.weapon.penetration ?? "0";
+    return replaceSymbols(penetrationFormula, actor, psyValue);
+}
+
+/**
+ *
+ * @param formula
+ * @param dos
+ * @param traits
+ */
+async function rollPenetration(formula, dos, traits) {
+    const roll = await new Roll(formula).evaluate({ async: true });
+    const multiplier = dos >= 3 && traits.razorSharp ? 2 : 1;
+    return roll.total * multiplier;
+}
+
+/**
+ *
+ * @param targets
+ */
+function formatTargetList(targets) {
+    if (!targets.length) return "No target";
+    return targets.map(token => token.name).join(", ");
+}
+
+/**
+ *
+ * @param root0
+ * @param root0.attacker
+ * @param root0.weapon
+ * @param root0.attackType
+ * @param root0.targetNumber
+ * @param root0.attackRoll
+ * @param root0.hits
+ * @param root0.targets
+ * @param root0.rangeSummary
+ */
+function buildAttackSummary({ attacker, weapon, attackType, targetNumber, attackRoll, hits, targets, rangeSummary }) {
+    const outcome = attackRoll.success ? (hits > 0 ? "hit" : "hit (no hits resolved)") : "missed";
+    const attackerLabel = `${attacker.name} (${getTargetTypeLabel(attacker)})`;
+    const targetLabel = formatTargetList(targets);
+    const rollLine = `${attackRoll.result}/${targetNumber}`;
+    const hitsLine = attackRoll.success ? `${hits} hits scored` : `${attackRoll.dof} DoF`;
+    const rangeLine = rangeSummary ? `<div class="dh-range">Range: ${rangeSummary}</div>` : "";
+
+    return `
+    <div class="dh-attack-summary">
+        <div><strong>${attackerLabel}</strong> ${outcome} <strong>${targetLabel}</strong> with <strong>${weapon.name}</strong> (${attackType.label}).</div>
+        <div class="dh-roll">(${rollLine} • ${hitsLine})</div>
+        ${rangeLine}
+    </div>`;
+}
+
+/**
+ *
+ * @param commandLabel
+ * @param payload
+ */
+function buildRerollButton(commandLabel, payload) {
+    const data = encodeURIComponent(JSON.stringify(payload));
+    return `<button type="button" class="dh-inline-action" data-dh-reroll="${data}">${commandLabel}</button>`;
+}
+
+/**
+ *
+ * @param defence
+ */
+function buildDefenceSummary(defence) {
+    if (!defence?.attempted) {
+        return `<div class="dh-defence">Defence: ${defence?.reason ?? "Not attempted"}.</div>`;
+    }
+    const label = defence.defenceType === "parry" ? "Parry" : defence.defenceType === "deny" ? "Deny the Witch" : "Dodge";
+    const outcome = defence.success ? "succeeded" : "failed";
+    return `<div class="dh-defence">Defence (${label}) ${outcome} (${defence.roll.result}/${defence.targetNumber}).</div>`;
+}
+
+/**
+ *
+ * @param damageEntries
+ */
+function buildDamageSummary(damageEntries) {
+    if (!damageEntries.length) return "<div class='dh-damage'>No damage rolled.</div>";
+    const rows = damageEntries.map((entry, index) => `
+        <li>
+            Hit ${index + 1}: <strong>${entry.location.label}</strong> — ${entry.damage.total} damage (Pen ${entry.damage.penetration})
+            ${entry.damage.righteousFury ? ` • RF ${entry.damage.righteousFury}` : ""}
+        </li>`).join("");
+    return `<div class="dh-damage"><ol>${rows}</ol></div>`;
+}
+
+/**
+ *
+ * @param payload
+ */
+function buildApplyDamageButton(payload) {
+    const data = encodeURIComponent(JSON.stringify(payload));
+    return `<button type="button" class="dh-inline-action" data-dh-apply="${data}">Apply Damage</button>`;
+}
+
+/**
+ *
+ * @param entries
+ * @param targets
+ */
+async function applyDamageToTargets(entries, targets) {
+    if (!entries.length || !targets.length) return;
+    const damages = entries.map(entry => ({
+        amount: entry.damage.total,
+        location: entry.location.armour,
+        penetration: entry.damage.penetration,
+        type: entry.damageType,
+        righteousFury: entry.damage.righteousFury
+    }));
+    for (const token of targets) {
+        await token.actor?.applyDamage?.(damages);
+    }
+}
+
+/**
+ *
+ * @param message
+ * @param html
+ */
+function activateChatListeners(message, html) {
+    html.find(".dh-inline-action[data-dh-reroll]").on("click", async ev => {
+        const payload = JSON.parse(decodeURIComponent(ev.currentTarget.dataset.dhReroll));
+        await runAttackWindow(payload.config);
+    });
+
+    html.find(".dh-inline-action[data-dh-apply]").on("click", async ev => {
+        const payload = JSON.parse(decodeURIComponent(ev.currentTarget.dataset.dhApply));
+        const targets = payload.targetIds
+            .map(id => canvas.tokens?.get(id))
+            .filter(token => token?.actor);
+        await applyDamageToTargets(payload.entries, targets);
+    });
+}
+
+Hooks.on("renderChatMessage", (message, html) => {
+    if (!message.getFlag("dark-heresy", "attackWindow")) return;
+    activateChatListeners(message, html);
+});
+
+/**
+ *
+ * @param actor
+ */
+function getOwnership(actor) {
+    return actor?.ownership ?? actor?.data?.ownership ?? {};
+}
+
+/**
+ *
+ * @param actor
+ */
+function userOwnsActor(actor) {
+    const ownership = getOwnership(actor);
+    const level = ownership[game.user.id] ?? ownership.default ?? 0;
+    return level >= CONST.DOCUMENT_OWNERSHIP_LEVELS.OWNER || game.user.isGM;
+}
+
+/**
+ *
+ * @param actor
+ * @param config
+ * @param targetNumber
+ * @param attackRoll
+ */
+async function handlePostRollFate(actor, config, targetNumber, attackRoll) {
+    if (attackRoll.success) return attackRoll;
+    const fateAvailable = Number(actor?.fate?.value ?? 0) > 0;
+    if (!fateAvailable || !userOwnsActor(actor)) return attackRoll;
+
+    return new Promise(resolve => {
+        const content = `
+        <p>${actor.name} failed the roll (${attackRoll.result}/${targetNumber}). Spend Fate?</p>
+        <p>Before: +20 to the target. After: +10 then reroll, or Fate reroll.</p>`;
+        new Dialog({
+            title: "Spend Fate",
+            content,
+            buttons: {
+                plusTen: {
+                    label: "+10 & Reroll",
+                    callback: async () => {
+                        const spent = await spendFate(actor);
+                        if (!spent) return resolve(attackRoll);
+                        const reroll = await rollAttack(targetNumber + 10);
+                        reroll.fateSpent = true;
+                        reroll.fateMode = "+10";
+                        resolve(reroll);
+                    }
+                },
+                reroll: {
+                    label: "Fate Reroll",
+                    callback: async () => {
+                        const spent = await spendFate(actor);
+                        if (!spent) return resolve(attackRoll);
+                        const reroll = await rollAttack(targetNumber);
+                        reroll.fateSpent = true;
+                        reroll.fateMode = "reroll";
+                        resolve(reroll);
+                    }
+                },
+                keep: {
+                    label: "Keep Result",
+                    callback: () => resolve(attackRoll)
+                }
+            },
+            default: "keep"
+        }).render(true);
+    });
+}
+
+/**
+ *
+ * @param root0
+ * @param root0.actor
+ * @param root0.token
+ * @param root0.weapons
+ * @param root0.attackTypes
+ * @param root0.defaultTargets
+ * @param root0.mode
+ * @param root0.defaultWeaponId
+ */
+function buildAttackDialogContent({ actor, token, weapons, attackTypes, defaultTargets, mode, defaultWeaponId }) {
+    const weaponOptions = buildWeaponOptions(weapons);
+    const targetNames = defaultTargets.map(target => target.name).join(", ") || "None";
+    const aimOptions = Object.entries(AIM_CONFIG)
+        .map(([key, config]) => `<option value="${key}">${config.label}</option>`)
+        .join("");
+    const attackTypeOptions = attackTypes
+        .map(key => `<option value="${key}">${ATTACK_TYPE_CONFIG[key].label}</option>`)
+        .join("");
+
+    const attackTab = `
+    <div class="form-group">
+        <label>Acting Token</label>
+        <div>${token?.name ?? "None"} (${actor?.name ?? "No actor"})</div>
+    </div>
+    <div class="form-group">
+        <label>Weapon</label>
+        <select name="weaponId">${weaponOptions}</select>
+        <div class="form-fields">
+            <label><input type="checkbox" name="randomWeapon" /> Random weapon</label>
+            <label><input type="checkbox" name="directDamage" /> Go straight to damage</label>
+        </div>
+    </div>
+    <div class="form-group">
+        <label>Attack Type</label>
+        <select name="attackType">${attackTypeOptions}</select>
+    </div>
+    <div class="form-group">
+        <label>Aim</label>
+        <select name="aim">${aimOptions}</select>
+    </div>
+    <div class="form-group">
+        <label>Fate (before roll)</label>
+        <label><input type="checkbox" name="fateBefore" /> Spend Fate for +20</label>
+    </div>`;
+
+    const targetingTab = `
+    <div class="form-group">
+        <label>Current Targets</label>
+        <div>${targetNames}</div>
+        <p class="notes">Use Foundry targeting (T key) to select one or more targets. Templates will update targets automatically.</p>
+    </div>
+    <div class="form-group">
+        <label>Template Options</label>
+        <div class="form-fields">
+            <button type="button" data-dh-template="blast">Place Blast Template</button>
+            <button type="button" data-dh-template="spray">Place Spray Template</button>
+        </div>
+    </div>`;
+
+    const modifiersTab = `
+    <div class="form-group">
+        <label>Manual Modifier</label>
+        <input type="number" name="manualMod" value="0" />
+    </div>
+    <div class="form-group">
+        <label>Range Modifier Override</label>
+        <input type="number" name="rangeOverride" placeholder="Auto" />
+    </div>
+    <div class="form-group">
+        <label>Cover Modifier</label>
+        <input type="number" name="coverMod" value="0" />
+        <label><input type="checkbox" name="considerWalls" /> Consider walls (manual only)</label>
+    </div>`;
+
+    const tabs = buildTabsContent([
+        { id: "attack", label: "Attack", content: attackTab },
+        { id: "targeting", label: "Targeting", content: targetingTab },
+        { id: "modifiers", label: "Modifiers", content: modifiersTab }
+    ]);
+
+    return `
+    <form class="dh-attack-window" data-mode="${mode}">
+        ${tabs}
+        <input type="hidden" name="defaultWeaponId" value="${defaultWeaponId ?? ""}" />
+    </form>`;
+}
+
+/**
+ *
+ * @param root0
+ * @param root0.actor
+ * @param root0.token
+ * @param root0.weapons
+ * @param root0.mode
+ */
+async function collectDialogResult({ actor, token, weapons, mode }) {
+    if (!actor) {
+        ui.notifications.warn("No actor selected for attack.");
+        return null;
+    }
+
+    const attackTypes = getAttackTypeOptions(mode);
+    const defaultTargets = resolveInitialTargets(token, actor);
+    const defaultWeaponId = weapons[0]?.id ?? "";
+
+    return new Promise(resolve => {
+        const content = buildAttackDialogContent({ actor, token, weapons, attackTypes, defaultTargets, mode, defaultWeaponId });
+        const dialog = new Dialog({
+            title: `${mode === "melee" ? "Melee" : "Ranged"} Attack`,
+            content,
+            buttons: {
+                attack: {
+                    label: "Attack",
+                    callback: html => {
+                        const weaponId = html.find("[name='weaponId']").val();
+                        const randomWeapon = html.find("[name='randomWeapon']").is(":checked");
+                        const directDamage = html.find("[name='directDamage']").is(":checked");
+                        const attackType = html.find("[name='attackType']").val();
+                        const aim = html.find("[name='aim']").val();
+                        const fateBefore = html.find("[name='fateBefore']").is(":checked");
+                        const manualMod = Number(html.find("[name='manualMod']").val() || 0);
+                        const rangeOverrideRaw = html.find("[name='rangeOverride']").val();
+                        const rangeOverride = rangeOverrideRaw === "" ? null : Number(rangeOverrideRaw);
+                        const coverMod = Number(html.find("[name='coverMod']").val() || 0);
+                        const considerWalls = html.find("[name='considerWalls']").is(":checked");
+                        resolve({ weaponId, randomWeapon, directDamage, attackType, aim, fateBefore, manualMod, rangeOverride, coverMod, considerWalls });
+                    }
+                },
+                cancel: {
+                    label: "Cancel",
+                    callback: () => resolve(null)
+                }
+            },
+            default: "attack",
+            render: html => {
+                activateTabs(html);
+                html.find("button[data-dh-template]").on("click", async ev => {
+                    const weaponId = html.find("[name='weaponId']").val();
+                    const weapon = weapons.find(item => item.id === weaponId);
+                    if (!weapon) {
+                        ui.notifications.warn("Select a weapon first.");
+                        return;
+                    }
+                    const rollData = buildWeaponRollData(actor, weapon);
+                    const traits = parseTraits(weapon, rollData);
+                    if (ev.currentTarget.dataset.dhTemplate === "blast") {
+                        if (!traits.blast) {
+                            ui.notifications.warn("Weapon does not have Blast (X).");
+                            return;
+                        }
+                        const { placeBlastTemplate } = await import("../common.js");
+                        await placeBlastTemplate(token, weapon);
+                    } else {
+                        if (!traits.spray) {
+                            ui.notifications.warn("Weapon does not have Spray.");
+                            return;
+                        }
+                        const { placeSprayTemplate } = await import("../common.js");
+                        await placeSprayTemplate(token, weapon);
+                    }
+                });
+            }
+        });
+        dialog.render(true);
+    });
+}
+
+/**
+ *
+ * @param token
+ * @param actor
+ * @param weapon
+ * @param rollData
+ * @param mode
+ */
+async function resolveTargetsForAttack(token, actor, weapon, rollData, mode) {
+    let targets = resolveInitialTargets(token, actor);
+    const traits = parseTraits(weapon, rollData);
+    const aoe = getAoEFlags(traits);
+
+    if (aoe.blast) {
+        const { placeBlastTemplate } = await import("../common.js");
+        const placed = await placeBlastTemplate(token, weapon);
+        if (placed.targets.length) targets = placed.targets;
+    } else if (aoe.spray) {
+        const { placeSprayTemplate } = await import("../common.js");
+        const placed = await placeSprayTemplate(token, weapon);
+        if (placed.targets.length) targets = placed.targets;
+    }
+
+    if (!targets.length) {
+        const explicit = Array.from(game.user?.targets ?? []).filter(target => target?.actor);
+        if (explicit.length) targets = explicit;
+    }
+
+    return targets;
+}
+
+/**
+ *
+ * @param root0
+ * @param root0.attackerActor
+ * @param root0.targetToken
+ * @param root0.weaponClass
+ * @param root0.attackLabel
+ */
+async function resolveDefenceFlow({ attackerActor, targetToken, weaponClass, attackLabel }) {
+    const attackerIsPC = attackerActor?.type === "acolyte";
+    const targetIsPC = targetToken?.actor?.type === "acolyte";
+
+    if (!targetToken?.actor) {
+        return { attempted: false, defenceType: "none", success: false, reason: "No target actor" };
+    }
+
+    if (attackerIsPC && !targetIsPC) {
+        const preferred = canParry(weaponClass) ? "parry" : "dodge";
+        return resolveDefenceRoll(targetToken, preferred, weaponClass);
+    }
+
+    if (!attackerIsPC && targetIsPC) {
+        const choice = await promptDefence(targetToken, weaponClass, attackLabel);
+        if (!choice || choice === "accept") {
+            return { attempted: false, defenceType: "accept", success: false, reason: "Accepted hit" };
+        }
+        return resolveDefenceRoll(targetToken, choice, weaponClass);
+    }
+
+    const preferred = canParry(weaponClass) ? "parry" : "dodge";
+    return resolveDefenceRoll(targetToken, preferred, weaponClass);
+}
+
+/**
+ *
+ * @param root0
+ * @param root0.actor
+ * @param root0.weapon
+ * @param root0.rollData
+ * @param root0.attackRoll
+ * @param root0.hits
+ * @param root0.targets
+ * @param root0.traits
+ * @param root0.mode
+ */
+async function resolveDamageEntries({ actor, weapon, rollData, attackRoll, hits, targets, traits, mode }) {
+    const psyValue = rollData.psy?.value ?? null;
+    const damageFormula = buildDamageFormula(actor, rollData, traits, psyValue);
+    const penetrationFormula = buildPenetrationFormula(actor, rollData, psyValue);
+    const penetration = await rollPenetration(penetrationFormula, attackRoll.dos, traits);
+    const weaponDamageType = rollData.weapon.damageType ?? weapon.system?.damageType ?? "impact";
+    const weaponClass = getWeaponClass(weapon);
+
+    const entries = [];
+    const baseLocation = getHitLocationFromRoll(attackRoll.result);
+    for (let i = 0; i < hits; i += 1) {
+        const location = i === 0 ? baseLocation : await rollRandomLocation();
+        const damage = await buildDamageRoll({ formula: damageFormula, traits, dos: attackRoll.dos, penetration });
+        const targetToken = targets[i % targets.length] ?? null;
+        const coverValue = targetToken?.actor ? getCoverValue(targetToken.actor, location.key) : 0;
+        let coverReduced = null;
+        if (targetToken?.actor && coverValue > 0 && penetration >= coverValue) {
+            coverReduced = await reduceCoverLevel(targetToken.actor, location.key);
+        }
+        entries.push({
+            location,
+            damage,
+            targetToken,
+            damageType: weaponDamageType,
+            coverValue,
+            coverReduced,
+            weaponClass
+        });
+    }
+    return entries;
+}
+
+/**
+ *
+ * @param entries
+ */
+function summarizeCoverReduction(entries) {
+    const reductions = entries.filter(entry => entry.coverReduced?.reduced);
+    if (!reductions.length) return "";
+    const lines = reductions.map(entry => `${entry.targetToken?.name ?? "Target"} cover reduced to ${entry.coverReduced.newLevelValue}`).join(" • ");
+    return `<div class="dh-cover">Cover penetrated: ${lines}</div>`;
+}
+
+/**
+ *
+ * @param root0
+ * @param root0.actor
+ * @param root0.weapon
+ * @param root0.attackType
+ * @param root0.targetNumber
+ * @param root0.attackRoll
+ * @param root0.hits
+ * @param root0.targets
+ * @param root0.entries
+ * @param root0.config
+ * @param root0.rangeSummary
+ * @param root0.defenceResults
+ */
+async function createAttackChatMessage({ actor, weapon, attackType, targetNumber, attackRoll, hits, targets, entries, config, rangeSummary, defenceResults }) {
+    const summary = buildAttackSummary({ attacker: actor, weapon, attackType, targetNumber, attackRoll, hits, targets, rangeSummary });
+    const defenceSummary = defenceResults.map(result => buildDefenceSummary(result)).join("");
+    const damageSummary = buildDamageSummary(entries);
+    const coverSummary = summarizeCoverReduction(entries);
+    const rerollButton = buildRerollButton("Redo (+20)", {
+        config: {
+            ...config,
+            manualMod: (config.manualMod ?? 0) + 20,
+            skipDialog: true
+        }
+    });
+
+    const applyButton = buildApplyDamageButton({
+        entries,
+        targetIds: targets.map(token => token.id)
+    });
+
+    const content = `
+    <div class="dh-attack-card">
+        ${summary}
+        <div class="dh-actions">${rerollButton}</div>
+        <hr />
+        ${defenceSummary}
+        ${coverSummary}
+        <hr />
+        ${damageSummary}
+        <div class="dh-actions">${applyButton}</div>
+    </div>`;
+
+    await ChatMessage.create({
+        content,
+        speaker: ChatMessage.getSpeaker({ actor }),
+        flags: {
+            "dark-heresy": {
+                attackWindow: true
+            }
+        }
+    });
+}
+
+/**
+ *
+ * @param config
+ */
+export async function runAttackWindow(config) {
+    const { token, actor } = resolveActorContext();
+    if (!actor) {
+        ui.notifications.warn("No actor available for attack.");
+        return;
+    }
+
+    const weapons = config.weapons;
+    const mode = config.mode;
+    if (!weapons.length) {
+        ui.notifications.warn("No valid weapons found for this macro.");
+        return;
+    }
+
+    let dialogResult = config.skipDialog ? config : await collectDialogResult({ actor, token, weapons, mode });
+    if (!dialogResult) return;
+
+    const weapon = resolveWeaponSelection(actor, weapons, dialogResult.weaponId, dialogResult.randomWeapon);
+    if (!weapon) {
+        ui.notifications.warn("No weapon selected.");
+        return;
+    }
+
+    const rollData = buildWeaponRollData(actor, weapon);
+    const traits = parseTraits(weapon, rollData);
+    const weaponClass = getWeaponClass(weapon);
+
+    const targets = await resolveTargetsForAttack(token, actor, weapon, rollData, mode);
+    const targetTokens = targets.length ? targets : [];
+
+    const attackType = determineAttackType(dialogResult.attackType ?? getDefaultAttackType(mode), rollData, mode);
+    const aim = AIM_CONFIG[dialogResult.aim] ?? AIM_CONFIG.none;
+    const fateBeforeMod = dialogResult.fateBefore ? 20 : 0;
+
+    const rangeData = resolveRangeData(token, targetTokens, rollData.weapon.range);
+    const autoRangeModifier = rangeData.modifier ?? 0;
+    const rangeModifier = dialogResult.rangeOverride ?? autoRangeModifier;
+
+    const manualMod = Number(dialogResult.manualMod ?? 0);
+    const coverMod = Number(dialogResult.coverMod ?? 0);
+
+    const baseTarget = rollData.target.base ?? 0;
+    let totalModifier = attackType.modifier + aim.modifier + fateBeforeMod + rangeModifier + manualMod + coverMod;
+    if (traits.twinLinked) totalModifier += 20;
+    if (traits.inaccurate) totalModifier -= 10;
+
+    const targetNumber = baseTarget + clampModifier(totalModifier);
+    const directDamage = !!dialogResult.directDamage;
+
+    let attackRoll = directDamage
+        ? {
+            result: null,
+            success: true,
+            dos: 1,
+            dof: 0
+        }
+        : await rollAttack(targetNumber);
+
+    if (!directDamage) {
+        attackRoll = await handlePostRollFate(actor, dialogResult, targetNumber, attackRoll);
+    }
+
+    const hits = attackRoll.success ? computeHitsOnSuccess(attackRoll.dos, attackType, traits) : 0;
+    const rangeSummary = rangeData.summary;
+
+    const defenceResults = [];
+    if (attackRoll.success && targetTokens.length) {
+        for (const targetToken of targetTokens) {
+            const defence = await resolveDefenceFlow({ attackerActor: actor, targetToken, weaponClass, attackLabel: weapon.name });
+            defenceResults.push(defence);
+        }
+    }
+
+    const anyDefended = defenceResults.some(result => result.success);
+    const resolvedHits = anyDefended ? Math.max(hits - 1, 0) : hits;
+
+    const entries = resolvedHits > 0
+        ? await resolveDamageEntries({ actor, weapon, rollData, attackRoll, hits: resolvedHits, targets: targetTokens.length ? targetTokens : [null], traits, mode })
+        : [];
+
+    await createAttackChatMessage({
+        actor,
+        weapon,
+        attackType,
+        targetNumber,
+        attackRoll,
+        hits: resolvedHits,
+        targets: targetTokens,
+        entries,
+        config: {
+            ...dialogResult,
+            mode
+        },
+        rangeSummary,
+        defenceResults
+    });
+}
+
+/**
+ *
+ * @param root0
+ * @param root0.mode
+ * @param root0.weapons
+ */
+export function createAttackMacroConfig({ mode, weapons }) {
+    return {
+        mode,
+        weapons
+    };
+}

--- a/script/macro/attack-windows/dialogs/defend-dialog.js
+++ b/script/macro/attack-windows/dialogs/defend-dialog.js
@@ -1,0 +1,286 @@
+import DarkHeresyUtil from "../../../common/util.js";
+import {
+    actorHasDenyTheWitch,
+    buildCharacteristicLookup,
+    ensureDenyTheWitchTalent,
+    resolveActorContext,
+    spendFate
+} from "../common.js";
+
+/**
+ *
+ * @param modifier
+ */
+function clampModifier(modifier) {
+    if (modifier > 60) return 60;
+    if (modifier < -60) return -60;
+    return modifier;
+}
+
+/**
+ *
+ * @param targetNumber
+ */
+async function rollTarget(targetNumber) {
+    const roll = await new Roll("1d100").evaluate({ async: true });
+    const result = roll.total;
+    const success = result <= targetNumber;
+    const degrees = success
+        ? 1 + Math.floor(targetNumber / 10) - Math.floor(result / 10)
+        : 1 + Math.floor(result / 10) - Math.floor(targetNumber / 10);
+    return {
+        roll,
+        result,
+        success,
+        dos: success ? degrees : 0,
+        dof: success ? 0 : degrees
+    };
+}
+
+/**
+ *
+ * @param sections
+ */
+function buildTabsContent(sections) {
+    const nav = sections
+        .map((section, index) => `<a class="item ${index === 0 ? "active" : ""}" data-tab="${section.id}">${section.label}</a>`)
+        .join("");
+    const body = sections
+        .map((section, index) => `
+            <div class="tab ${index === 0 ? "active" : ""}" data-tab="${section.id}">
+                ${section.content}
+            </div>`)
+        .join("");
+    return `
+    <div class="dh-tabs">
+        <nav class="tabs" data-group="dh-defend-tabs">${nav}</nav>
+        <section class="tab-content">${body}</section>
+    </div>`;
+}
+
+/**
+ *
+ * @param html
+ */
+function activateTabs(html) {
+    const tabs = html.find(".dh-tabs nav .item");
+    tabs.on("click", ev => {
+        ev.preventDefault();
+        const tab = ev.currentTarget.dataset.tab;
+        tabs.removeClass("active");
+        html.find(`.dh-tabs nav .item[data-tab='${tab}']`).addClass("active");
+        html.find(".dh-tabs .tab").removeClass("active");
+        html.find(`.dh-tabs .tab[data-tab='${tab}']`).addClass("active");
+    });
+}
+
+/**
+ *
+ * @param actor
+ * @param denyAvailable
+ */
+function buildDialogContent(actor, denyAvailable) {
+    const denyOption = denyAvailable ? "" : "disabled";
+    const tabs = buildTabsContent([
+        {
+            id: "defence",
+            label: "Defence",
+            content: `
+            <div class="form-group">
+                <label>Defence Type</label>
+                <select name="defenceType">
+                    <option value="dodge">Dodge</option>
+                    <option value="parry">Parry (+10)</option>
+                    <option value="deny" ${denyOption}>Deny the Witch</option>
+                </select>
+            </div>
+            <div class="form-group">
+                <label>Manual Modifier</label>
+                <input type="number" name="manualMod" value="0" />
+            </div>
+            <div class="form-group">
+                <label>Fate (before roll)</label>
+                <label><input type="checkbox" name="fateBefore" /> Spend Fate for +20</label>
+            </div>`
+        },
+        {
+            id: "stats",
+            label: "Stats",
+            content: `
+            <p>Weapon Skill: ${actor.characteristics.weaponSkill.total}</p>
+            <p>Ballistic Skill: ${actor.characteristics.ballisticSkill.total}</p>
+            <p>Willpower: ${actor.characteristics.willpower.total}</p>
+            <p>Agility: ${actor.characteristics.agility.total}</p>`
+        }
+    ]);
+
+    return `
+    <form class="dh-defend-window">
+        <div class="form-group">
+            <label>Actor</label>
+            <div>${actor.name}</div>
+        </div>
+        ${tabs}
+    </form>`;
+}
+
+/**
+ *
+ * @param actor
+ * @param targetNumber
+ * @param rollResult
+ */
+async function handlePostRollFate(actor, targetNumber, rollResult) {
+    if (rollResult.success) return rollResult;
+    const available = Number(actor?.fate?.value ?? 0) > 0;
+    if (!available) return rollResult;
+
+    return new Promise(resolve => {
+        new Dialog({
+            title: "Spend Fate",
+            content: `<p>${actor.name} failed (${rollResult.result}/${targetNumber}). Spend Fate?</p>`,
+            buttons: {
+                plusTen: {
+                    label: "+10 & Reroll",
+                    callback: async () => {
+                        const spent = await spendFate(actor);
+                        if (!spent) return resolve(rollResult);
+                        const reroll = await rollTarget(targetNumber + 10);
+                        reroll.fateSpent = true;
+                        resolve(reroll);
+                    }
+                },
+                reroll: {
+                    label: "Fate Reroll",
+                    callback: async () => {
+                        const spent = await spendFate(actor);
+                        if (!spent) return resolve(rollResult);
+                        const reroll = await rollTarget(targetNumber);
+                        reroll.fateSpent = true;
+                        resolve(reroll);
+                    }
+                },
+                keep: {
+                    label: "Keep Result",
+                    callback: () => resolve(rollResult)
+                }
+            },
+            default: "keep"
+        }).render(true);
+    });
+}
+
+/**
+ *
+ * @param actor
+ * @param defenceType
+ * @param manualMod
+ * @param fateBefore
+ */
+async function resolveDefenceRoll(actor, defenceType, manualMod, fateBefore) {
+    const defenceData = defenceType === "deny"
+        ? DarkHeresyUtil.createCharacteristicRollData(actor, "willpower")
+        : DarkHeresyUtil.createSkillRollData(actor, defenceType);
+
+    if (defenceType === "parry") {
+        defenceData.target.modifier = (defenceData.target.modifier ?? 0) + 10;
+    }
+
+    const fateBeforeMod = fateBefore ? 20 : 0;
+    const modifier = (defenceData.target.modifier ?? 0) + manualMod + fateBeforeMod;
+    const targetNumber = (defenceData.target.base ?? 0) + clampModifier(modifier);
+    let rollResult = await rollTarget(targetNumber);
+    rollResult = await handlePostRollFate(actor, targetNumber, rollResult);
+    return { defenceData, targetNumber, rollResult };
+}
+
+/**
+ *
+ * @param root0
+ * @param root0.actor
+ * @param root0.defenceType
+ * @param root0.targetNumber
+ * @param root0.rollResult
+ * @param root0.manualMod
+ */
+async function sendDefenceToChat({ actor, defenceType, targetNumber, rollResult, manualMod }) {
+    const labelMap = {
+        dodge: "Dodge",
+        parry: "Parry",
+        deny: "Deny the Witch"
+    };
+    const label = labelMap[defenceType] ?? defenceType;
+    const outcome = rollResult.success ? "succeeded" : "failed";
+    const characteristics = buildCharacteristicLookup(actor);
+    const statSummary = `WS ${characteristics.weaponSkill.total} • BS ${characteristics.ballisticSkill.total} • WP ${characteristics.willpower.total}`;
+
+    const content = `
+    <div class="dh-defend-card">
+        <div><strong>${actor.name}</strong> attempts to ${label}.</div>
+        <div>Target: ${targetNumber} (${manualMod >= 0 ? "+" : ""}${manualMod} manual)</div>
+        <div>Result: ${rollResult.result}/${targetNumber} — ${outcome} (${rollResult.success ? rollResult.dos : rollResult.dof} ${rollResult.success ? "DoS" : "DoF"})</div>
+        <div class="notes">${statSummary}</div>
+    </div>`;
+
+    await ChatMessage.create({
+        content,
+        speaker: ChatMessage.getSpeaker({ actor })
+    });
+}
+
+/**
+ *
+ */
+export async function runDefendDialog() {
+    const { actor } = resolveActorContext();
+    if (!actor) {
+        ui.notifications.warn("No actor available to defend.");
+        return;
+    }
+
+    if (game.user.isGM) {
+        await ensureDenyTheWitchTalent();
+    }
+
+    const denyAvailable = actorHasDenyTheWitch(actor);
+
+    const result = await new Promise(resolve => {
+        const content = buildDialogContent(actor, denyAvailable);
+        new Dialog({
+            title: "Defend",
+            content,
+            buttons: {
+                defend: {
+                    label: "Roll Defence",
+                    callback: html => {
+                        const defenceType = html.find("[name='defenceType']").val();
+                        const manualMod = Number(html.find("[name='manualMod']").val() || 0);
+                        const fateBefore = html.find("[name='fateBefore']").is(":checked");
+                        resolve({ defenceType, manualMod, fateBefore });
+                    }
+                },
+                cancel: {
+                    label: "Cancel",
+                    callback: () => resolve(null)
+                }
+            },
+            default: "defend",
+            render: html => activateTabs(html)
+        }).render(true);
+    });
+
+    if (!result) return;
+    if (result.defenceType === "deny" && !denyAvailable) {
+        ui.notifications.warn("Deny the Witch is not available on this actor.");
+        return;
+    }
+
+    const defenceRoll = await resolveDefenceRoll(actor, result.defenceType, result.manualMod, result.fateBefore);
+    await sendDefenceToChat({
+        actor,
+        defenceType: result.defenceType,
+        targetNumber: defenceRoll.targetNumber,
+        rollResult: defenceRoll.rollResult,
+        manualMod: result.manualMod
+    });
+}

--- a/script/macro/attack-windows/dialogs/power-attack-dialog.js
+++ b/script/macro/attack-windows/dialogs/power-attack-dialog.js
@@ -1,0 +1,267 @@
+import DarkHeresyUtil from "../../../common/util.js";
+import {
+    extractNumericTrait,
+    getHitLocationFromRoll,
+    resolveActorContext,
+    resolveInitialTargets,
+    resolveRangeData,
+    rollRandomLocation
+} from "../common.js";
+
+/**
+ *
+ * @param modifier
+ */
+function clampModifier(modifier) {
+    if (modifier > 60) return 60;
+    if (modifier < -60) return -60;
+    return modifier;
+}
+
+/**
+ *
+ * @param targetNumber
+ */
+async function rollTarget(targetNumber) {
+    const roll = await new Roll("1d100").evaluate({ async: true });
+    const result = roll.total;
+    const success = result <= targetNumber;
+    const degrees = success
+        ? 1 + Math.floor(targetNumber / 10) - Math.floor(result / 10)
+        : 1 + Math.floor(result / 10) - Math.floor(targetNumber / 10);
+    return {
+        roll,
+        result,
+        success,
+        dos: success ? degrees : 0,
+        dof: success ? 0 : degrees
+    };
+}
+
+/**
+ *
+ * @param formula
+ * @param actor
+ * @param psyValue
+ */
+function replaceSymbols(formula, actor, psyValue) {
+    if (!formula) return "0";
+    let updated = `${formula}`.replaceAll(/PR/gi, psyValue);
+    for (const bonus of actor.attributeBoni ?? []) {
+        updated = updated.replaceAll(bonus.regex, bonus.value);
+    }
+    return updated;
+}
+
+/**
+ *
+ * @param roll
+ */
+function extractDiceTerms(roll) {
+    const diceTerms = [];
+    for (const term of roll.terms ?? []) {
+        if (term?.faces) {
+            for (const result of term.results ?? []) {
+                diceTerms.push({ faces: term.faces, result });
+            }
+        }
+    }
+    return diceTerms;
+}
+
+/**
+ *
+ * @param diceTerms
+ * @param minimum
+ */
+function applyDosMinimum(diceTerms, minimum) {
+    if (!minimum || minimum <= 0) return;
+    const active = diceTerms.filter(entry => entry.result?.active !== false);
+    if (!active.length) return;
+    active.sort((a, b) => (a.result.result ?? 0) - (b.result.result ?? 0));
+    const die = active[0];
+    if ((die.result.result ?? 0) < minimum) {
+        die.result.result = minimum;
+    }
+}
+
+/**
+ *
+ * @param actor
+ * @param rollData
+ * @param attackRoll
+ */
+async function buildPowerDamage(actor, rollData, attackRoll) {
+    const traits = rollData.weapon.traits ?? {};
+    const damageFormula = replaceSymbols(rollData.weapon.damageFormula, actor, rollData.psy.value);
+    const damageRoll = await new Roll(`${damageFormula}+${rollData.weapon.damageBonus ?? 0}`).evaluate({ async: true });
+    const diceTerms = extractDiceTerms(damageRoll);
+    applyDosMinimum(diceTerms, attackRoll.dos);
+    const total = damageRoll._evaluateTotal();
+    const penetrationFormula = replaceSymbols(rollData.weapon.penetrationFormula ?? "0", actor, rollData.psy.value);
+    const penetrationRoll = await new Roll(penetrationFormula).evaluate({ async: true });
+    const penetration = penetrationRoll.total;
+    return { total, penetration, traits, damageRoll };
+}
+
+/**
+ *
+ * @param actor
+ * @param powers
+ * @param title
+ */
+function buildDialogContent(actor, powers, title) {
+    const options = powers.map(power => `<option value="${power.id}">${power.name}</option>`).join("");
+    return `
+    <form class="dh-power-window">
+        <div class="form-group">
+            <label>Actor</label>
+            <div>${actor.name}</div>
+        </div>
+        <div class="form-group">
+            <label>${title}</label>
+            <select name="powerId">${options}</select>
+        </div>
+        <div class="form-group">
+            <label>Psy Rating</label>
+            <input type="number" name="psyValue" value="${actor.psy.rating}" min="0" />
+        </div>
+        <div class="form-group">
+            <label>Manual Modifier</label>
+            <input type="number" name="manualMod" value="0" />
+        </div>
+    </form>`;
+}
+
+/**
+ *
+ * @param actor
+ * @param powers
+ * @param title
+ */
+async function resolveDialog(actor, powers, title) {
+    if (!powers.length) {
+        ui.notifications.warn("No psychic powers available.");
+        return null;
+    }
+    return new Promise(resolve => {
+        const content = buildDialogContent(actor, powers, title);
+        new Dialog({
+            title,
+            content,
+            buttons: {
+                roll: {
+                    label: "Roll",
+                    callback: html => {
+                        const powerId = html.find("[name='powerId']").val();
+                        const psyValue = Number(html.find("[name='psyValue']").val() || actor.psy.rating);
+                        const manualMod = Number(html.find("[name='manualMod']").val() || 0);
+                        resolve({ powerId, psyValue, manualMod });
+                    }
+                },
+                cancel: {
+                    label: "Cancel",
+                    callback: () => resolve(null)
+                }
+            },
+            default: "roll"
+        }).render(true);
+    });
+}
+
+/**
+ *
+ * @param root0
+ * @param root0.actor
+ * @param root0.power
+ * @param root0.attackRoll
+ * @param root0.targetNumber
+ * @param root0.targets
+ * @param root0.damageEntries
+ * @param root0.rangeSummary
+ */
+async function sendPowerToChat({ actor, power, attackRoll, targetNumber, targets, damageEntries, rangeSummary }) {
+    const targetLabel = targets.length ? targets.map(token => token.name).join(", ") : "No target";
+    const outcome = attackRoll.success ? "hit" : "missed";
+    const damages = damageEntries.map((entry, index) => `<li>Hit ${index + 1}: ${entry.location.label} — ${entry.damage.total} (Pen ${entry.damage.penetration})</li>`).join("");
+    const rangeLine = rangeSummary ? `<div class="dh-range">Range: ${rangeSummary}</div>` : "";
+
+    const content = `
+    <div class="dh-power-card">
+        <div><strong>${actor.name}</strong> uses <strong>${power.name}</strong> and ${outcome} <strong>${targetLabel}</strong>.</div>
+        <div>Roll: ${attackRoll.result}/${targetNumber} (${attackRoll.success ? attackRoll.dos : attackRoll.dof} ${attackRoll.success ? "DoS" : "DoF"})</div>
+        ${rangeLine}
+        <ol>${damages}</ol>
+    </div>`;
+
+    await ChatMessage.create({
+        content,
+        speaker: ChatMessage.getSpeaker({ actor })
+    });
+}
+
+/**
+ *
+ * @param actor
+ * @param power
+ * @param rollData
+ * @param attackRoll
+ * @param targets
+ */
+async function resolveDamageEntries(actor, power, rollData, attackRoll, targets) {
+    const traits = rollData.weapon.traits ?? {};
+    const blast = extractNumericTrait(power.system?.damage?.special ?? "", /Blast\s*\((\d+)\)/i);
+    const hits = attackRoll.success ? Math.max(1, attackRoll.dos) : 0;
+    const entries = [];
+    const baseLocation = getHitLocationFromRoll(attackRoll.result);
+
+    for (let i = 0; i < hits; i += 1) {
+        const location = i === 0 ? baseLocation : await rollRandomLocation();
+        const damage = await buildPowerDamage(actor, rollData, attackRoll);
+        entries.push({ location, damage, blast, target: targets[i % (targets.length || 1)] });
+    }
+    return entries;
+}
+
+/**
+ *
+ * @param root0
+ * @param root0.navigator
+ */
+export async function runPowerAttackDialog({ navigator = false } = {}) {
+    const { actor, token } = resolveActorContext();
+    if (!actor) {
+        ui.notifications.warn("No actor available.");
+        return;
+    }
+
+    const powers = actor.items.filter(item => item.type === "psychicPower");
+    const title = navigator ? "Navigator Attack" : "Psychic Attack";
+    const dialogResult = await resolveDialog(actor, powers, title);
+    if (!dialogResult) return;
+
+    const power = powers.find(item => item.id === dialogResult.powerId);
+    if (!power) {
+        ui.notifications.warn("Selected power not found.");
+        return;
+    }
+
+    const rollData = DarkHeresyUtil.createPsychicRollData(actor, power);
+    rollData.psy.value = dialogResult.psyValue;
+
+    const targets = resolveInitialTargets(token, actor);
+    const rangeData = resolveRangeData(token, targets, rollData.weapon.range);
+    const targetNumber = (rollData.target.base ?? 0) + clampModifier((rollData.target.modifier ?? 0) + dialogResult.manualMod + (rangeData.modifier ?? 0));
+    const attackRoll = await rollTarget(targetNumber);
+    const damageEntries = attackRoll.success ? await resolveDamageEntries(actor, power, rollData, attackRoll, targets) : [];
+
+    await sendPowerToChat({
+        actor,
+        power,
+        attackRoll,
+        targetNumber,
+        targets,
+        damageEntries,
+        rangeSummary: rangeData.summary
+    });
+}

--- a/script/macro/attack-windows/index.js
+++ b/script/macro/attack-windows/index.js
@@ -1,0 +1,177 @@
+import { buildMacroOwnership, ensureDenyTheWitchTalent, resolveActorContext } from "./common.js";
+import { createAttackMacroConfig, runAttackWindow } from "./dialogs/attack-dialog.js";
+import { runDefendDialog } from "./dialogs/defend-dialog.js";
+import { runPowerAttackDialog } from "./dialogs/power-attack-dialog.js";
+import { runSpecialAttackDialog } from "./special-attacks/index.js";
+import { runApplyCoverDialog } from "./cover/index.js";
+
+const ROOT_FOLDER = "DH2e Automation";
+const FOLDER_MAP = Object.freeze({
+    ranged: "Ranged Attacking",
+    melee: "Melee Attacking",
+    defend: "Defending",
+    psychic: "Psychic Attack",
+    navigator: "Navigator Attack",
+    special: "Other Special Attack",
+    cover: "Apply Cover"
+});
+
+const MACRO_DEFINITIONS = Object.freeze([
+    {
+        key: "ranged",
+        name: "Ranged Attacking",
+        command: "game.darkHeresy.macros.attackWindows.rangedAttack();"
+    },
+    {
+        key: "melee",
+        name: "Melee Attacking",
+        command: "game.darkHeresy.macros.attackWindows.meleeAttack();"
+    },
+    {
+        key: "defend",
+        name: "Defending",
+        command: "game.darkHeresy.macros.attackWindows.defend();"
+    },
+    {
+        key: "psychic",
+        name: "Psychic Attack",
+        command: "game.darkHeresy.macros.attackWindows.psychicAttack();"
+    },
+    {
+        key: "navigator",
+        name: "Navigator Attack",
+        command: "game.darkHeresy.macros.attackWindows.navigatorAttack();"
+    },
+    {
+        key: "special",
+        name: "Other Special Attack",
+        command: "game.darkHeresy.macros.attackWindows.specialAttack();"
+    },
+    {
+        key: "cover",
+        name: "Apply Cover",
+        command: "game.darkHeresy.macros.attackWindows.applyCover();"
+    }
+]);
+
+/**
+ *
+ * @param key
+ */
+function getFolderPath(key) {
+    return [ROOT_FOLDER, FOLDER_MAP[key]].filter(Boolean);
+}
+
+/**
+ *
+ * @param pathParts
+ */
+async function ensureFolderPath(pathParts) {
+    let parentId = null;
+    for (const name of pathParts) {
+        const currentParentId = parentId;
+        let folder = game.folders.find(entry => entry.type === "Macro" && entry.name === name && entry.folder?.id === currentParentId);
+        if (!folder) {
+            folder = await Folder.create({
+                name,
+                type: "Macro",
+                folder: currentParentId,
+                ownership: buildMacroOwnership()
+            });
+        }
+        parentId = folder.id;
+    }
+    return parentId;
+}
+
+/**
+ *
+ * @param definition
+ */
+async function ensureMacro(definition) {
+    const folderId = await ensureFolderPath(getFolderPath(definition.key));
+    let macro = game.macros.find(entry => entry.name === definition.name && entry.command === definition.command);
+    const ownership = buildMacroOwnership();
+
+    if (!macro) {
+        macro = await Macro.create({
+            name: definition.name,
+            type: "script",
+            img: "icons/skills/ranged/target-bullseye-arrow-glowing.webp",
+            command: definition.command,
+            folder: folderId,
+            ownership
+        }, { displaySheet: false });
+        return macro;
+    }
+
+    const updates = {};
+    if (macro.folder?.id !== folderId) updates.folder = folderId;
+    updates.ownership = ownership;
+    if (Object.keys(updates).length) {
+        await macro.update(updates);
+    }
+    return macro;
+}
+
+/**
+ *
+ * @param mode
+ */
+function getWeaponsByMode(mode) {
+    const { actor } = resolveActorContext();
+    if (!actor) return [];
+    const weapons = actor.items.filter(item => item.type === "weapon");
+    if (mode === "melee") {
+        return weapons.filter(item => ["melee", "pistol"].includes(item.system?.class ?? item.class));
+    }
+    if (mode === "ranged") {
+        return weapons.filter(item => (item.system?.class ?? item.class) !== "melee");
+    }
+    return weapons;
+}
+
+/**
+ *
+ * @param mode
+ */
+async function runAttack(mode) {
+    const weapons = getWeaponsByMode(mode);
+    const config = createAttackMacroConfig({ mode, weapons });
+    await runAttackWindow(config);
+}
+
+/**
+ *
+ */
+export function registerAttackWindows() {
+    if (!game.darkHeresy.macros) game.darkHeresy.macros = {};
+
+    game.darkHeresy.macros.attackWindows = {
+        rangedAttack: () => runAttack("ranged"),
+        meleeAttack: () => runAttack("melee"),
+        defend: () => runDefendDialog(),
+        psychicAttack: () => runPowerAttackDialog({ navigator: false }),
+        navigatorAttack: () => runPowerAttackDialog({ navigator: true }),
+        specialAttack: () => runSpecialAttackDialog(),
+        applyCover: () => runApplyCoverDialog()
+    };
+
+    if (!game.macro) game.macro = {};
+    game.macro.attackWindows = game.darkHeresy.macros.attackWindows;
+}
+
+/**
+ *
+ */
+async function ensureMacrosReady() {
+    if (!game.user.isGM) return;
+    await ensureDenyTheWitchTalent();
+    for (const definition of MACRO_DEFINITIONS) {
+        await ensureMacro(definition);
+    }
+}
+
+Hooks.once("ready", () => {
+    ensureMacrosReady();
+});

--- a/script/macro/attack-windows/special-attacks/index.js
+++ b/script/macro/attack-windows/special-attacks/index.js
@@ -1,0 +1,157 @@
+import { buildMacroOwnership, resolveActorContext } from "../common.js";
+
+const JOURNAL_NAME = "Special Attacks";
+
+/**
+ *
+ */
+async function ensureJournal() {
+    let journal = game.journal?.find(entry => entry.name === JOURNAL_NAME);
+    if (journal) return journal;
+    journal = await JournalEntry.create({
+        name: JOURNAL_NAME,
+        ownership: buildMacroOwnership()
+    }, { renderSheet: false });
+    return journal;
+}
+
+/**
+ *
+ * @param page
+ */
+function extractScriptFromPage(page) {
+    if (!page) return "";
+    return page.text?.content ?? "";
+}
+
+/**
+ *
+ * @param pages
+ */
+function buildDialogContent(pages) {
+    const options = pages.map(page => `<option value="${page.id}">${page.name}</option>`).join("");
+    return `
+    <form class="dh-special-attack">
+        <div class="form-group">
+            <label>Saved Attacks</label>
+            <select name="pageId">
+                <option value="">-- New Attack --</option>
+                ${options}
+            </select>
+        </div>
+        <div class="form-group">
+            <label>Attack Name</label>
+            <input type="text" name="attackName" />
+        </div>
+        <div class="form-group">
+            <label>Attack Script</label>
+            <textarea name="attackScript" rows="10" placeholder="Write a macro script here..."></textarea>
+        </div>
+        <div class="form-group">
+            <label><input type="checkbox" name="saveToJournal" /> Save/Update in journal</label>
+        </div>
+    </form>`;
+}
+
+/**
+ *
+ * @param journal
+ * @param name
+ * @param script
+ * @param existingPageId
+ */
+async function upsertJournalPage(journal, name, script, existingPageId = "") {
+    const pages = journal.pages ?? [];
+    const existing = existingPageId ? pages.get(existingPageId) : pages.find(page => page.name === name);
+    if (existing) {
+        await existing.update({ name, "text.content": script });
+        return existing;
+    }
+    const created = await journal.createEmbeddedDocuments("JournalEntryPage", [{
+        name,
+        type: "text",
+        text: { content: script }
+    }]);
+    return created?.[0] ?? null;
+}
+
+/**
+ *
+ * @param script
+ * @param actor
+ */
+async function executeScript(script, actor) {
+    if (!script.trim()) {
+        ui.notifications.warn("No script provided for special attack.");
+        return;
+    }
+    try {
+        const fn = new Function("actor", "token", script);
+        const token = actor?.getActiveTokens?.(true, true)?.[0] ?? null;
+        await fn(actor, token);
+    } catch(error) {
+        console.error(error);
+        ui.notifications.error(`Special attack failed: ${error.message}`);
+    }
+}
+
+/**
+ *
+ */
+export async function runSpecialAttackDialog() {
+    const { actor } = resolveActorContext();
+    if (!actor) {
+        ui.notifications.warn("No actor available for special attacks.");
+        return;
+    }
+
+    const journal = await ensureJournal();
+    const pages = journal.pages?.contents ?? [];
+
+    const dialogResult = await new Promise(resolve => {
+        const content = buildDialogContent(pages);
+        new Dialog({
+            title: "Other Special Attack",
+            content,
+            buttons: {
+                run: {
+                    label: "Run Attack",
+                    callback: html => {
+                        const pageId = html.find("[name='pageId']").val();
+                        const attackName = html.find("[name='attackName']").val();
+                        const attackScript = html.find("[name='attackScript']").val();
+                        const saveToJournal = html.find("[name='saveToJournal']").is(":checked");
+                        resolve({ pageId, attackName, attackScript, saveToJournal });
+                    }
+                },
+                cancel: {
+                    label: "Cancel",
+                    callback: () => resolve(null)
+                }
+            },
+            default: "run",
+            render: html => {
+                html.find("[name='pageId']").on("change", ev => {
+                    const pageId = ev.currentTarget.value;
+                    const page = pages.find(entry => entry.id === pageId);
+                    if (!page) return;
+                    html.find("[name='attackName']").val(page.name);
+                    html.find("[name='attackScript']").val(extractScriptFromPage(page));
+                });
+            }
+        }).render(true);
+    });
+
+    if (!dialogResult) return;
+
+    const attackName = dialogResult.attackName?.trim() || (pages.find(page => page.id === dialogResult.pageId)?.name ?? "Special Attack");
+    const script = dialogResult.attackScript?.trim() || extractScriptFromPage(pages.find(page => page.id === dialogResult.pageId));
+
+    let savedPage = null;
+    if (dialogResult.saveToJournal && attackName) {
+        savedPage = await upsertJournalPage(journal, attackName, script, dialogResult.pageId);
+        ui.notifications.info(savedPage ? `Saved special attack: ${attackName}` : "Unable to save special attack.");
+    }
+
+    await executeScript(script, actor);
+}


### PR DESCRIPTION
### Motivation
- Provide a set of built-in, foldered macros and dialogs for the system to handle ranged/melee/psychic/navigator/special attacks, defensive reactions, and cover application as a cohesive UI workflow. 
- Implement attacker/target defaults, AoE template support, range bands, hit location mapping, fate spending, cover degradation and clear chat output to match requested game flow.

### Description
- Add a new macro subsystem under `script/macro/attack-windows/` with `common.js` utilities, dialog implementations (`attack-dialog.js`, `defend-dialog.js`, `power-attack-dialog.js`), a special-attacks journal-backed dialog, and an apply-cover dialog and helpers. 
- Register the attack windows during system init by importing and calling `registerAttackWindows()` from `script/dark-heresy.js`, exposing `game.darkHeresy.macros.attackWindows.*` and `game.macro.attackWindows` APIs. 
- Auto-create a structured macro folder tree and macros (GM-only edit ownership, world-executable by players) and provide `buildMacroOwnership()` so macros are available to all players but editable by GMs only. 
- Implement core features: actor/token resolution, nearest-opposition targeting defaults, range normalization and band modifiers, AoE template placement (Blast/Spray) and token collection, hit-location mapping (reversing first roll), DoS-driven minimum-die adjustments (Proven/Primitive/Tearing handling), fate spending (before/after options), cover item creation and level degradation, and rich chat messages with inline reroll/apply-damage actions. 
- Ensure the base talent `Deny the Witch` exists (created in world items when missing) and wire checks for deny/parry/dodge availability in defend flows, plus a Special Attacks dialog that can save scripts to a journaling entry for reuse.

### Testing
- Ran `npm test` (which invokes `gulp lint --fix`) and the lint workflow completed successfully; the repo emits existing lint warnings but the test task finished without errors. 
- Ran `npx gulp lint` separately to re-check and the linter completed (warnings only) confirming the new files are syntactically valid and integrated into the build lint pass.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974c3acdfd08327a84c9c5d9039c59a)