### PR TITLE
Add documentation hub and standardize release zip naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 An **UNOFFICIAL** system for playing Dark Heresy 2E on [Foundry VTT](https://foundryvtt.com/).
 
-Originally created by Necaladun, this fork lives under the USBinquisition banner and updates the system for Foundry V13's jQuery changes. It's vibe-coded and checked over with his limited skills.
+Originally created by Necaladun, this fork updates the system for Foundry V13's jQuery changes and continues Dark Heresy 2E automation work.
 
 It provides support for **character sheets only**, game content should be drawn from official source books.
 
@@ -10,7 +10,7 @@ The project is being continued under the GPL-3.0 License after the original auth
 
 ## Install
 1. Go to the setup page and choose **Game Systems**.
-2. Click the **Install System** button, and paste in this [manifest link](https://github.com/USBinquisition/FoundryVTT-40k/releases/download/0.6a/system.json).
+2. Click the **Install System** button, and paste in this [manifest link](https://github.com/FoundryVTT-40k/FoundryVTT-40k/releases/download/0.6a/system.json).
 3. Create a Game World using the Dark Heresy system.
 
 ## Preview

--- a/build/build.bat
+++ b/build/build.bat
@@ -9,7 +9,7 @@ if "%RELEASE_VERSION%"=="" set "RELEASE_VERSION=%DEFAULT_VERSION%"
 
 set "BUILD_DIR=%ROOT%\build"
 set "RELEASE_DIR=%BUILD_DIR%\release"
-set "ZIP_NAME=%RELEASE_VERSION%USB.zip"
+set "ZIP_NAME=%RELEASE_VERSION%.zip"
 
 if exist "%RELEASE_DIR%" rmdir /s /q "%RELEASE_DIR%"
 mkdir "%RELEASE_DIR%"

--- a/docs/examples/actor-acolyte.json
+++ b/docs/examples/actor-acolyte.json
@@ -1,0 +1,42 @@
+{
+  "name": "Example Acolyte",
+  "type": "acolyte",
+  "img": "icons/svg/mystery-man.svg",
+  "system": {
+    "characteristics": {
+      "weaponSkill": { "base": 35, "advance": 5, "unnatural": 0, "damage": 0 },
+      "ballisticSkill": { "base": 38, "advance": 2, "unnatural": 0, "damage": 0 },
+      "strength": { "base": 32, "advance": 0, "unnatural": 0, "damage": 0 },
+      "toughness": { "base": 34, "advance": 0, "unnatural": 0, "damage": 0 },
+      "agility": { "base": 36, "advance": 0, "unnatural": 0, "damage": 0 },
+      "intelligence": { "base": 40, "advance": 5, "unnatural": 0, "damage": 0 },
+      "perception": { "base": 37, "advance": 0, "unnatural": 0, "damage": 0 },
+      "willpower": { "base": 39, "advance": 0, "unnatural": 0, "damage": 0 },
+      "fellowship": { "base": 33, "advance": 0, "unnatural": 0, "damage": 0 },
+      "influence": { "base": 25, "advance": 0, "unnatural": 0, "damage": 0 }
+    },
+    "skills": {
+      "awareness": { "advance": 0, "modifier": 0 },
+      "athletics": { "advance": 0, "modifier": 0 },
+      "commonLore": { "advance": 10, "modifier": 0, "specialities": { "imperium": { "advance": 10, "modifier": 0 } } },
+      "dodge": { "advance": 0, "modifier": 0 },
+      "inquiry": { "advance": 0, "modifier": 0 }
+    },
+    "experience": { "value": 1200 },
+    "faction": "Ordo Hereticus",
+    "insanity": 3,
+    "corruption": 1,
+    "size": 4,
+    "wounds": { "max": 12, "value": 12 },
+    "fatigue": { "max": 9, "value": 0 },
+    "fate": { "max": 3, "value": 2 },
+    "psy": { "rating": 0, "sustained": 0, "class": "bound", "cost": 0 },
+    "bio": {
+      "homeWorld": "Hive World",
+      "background": "Adeptus Administratum",
+      "role": "Seeker",
+      "divination": "Knowledge is power",
+      "notes": "Template actor showing typical acolyte structure."
+    }
+  }
+}

--- a/docs/examples/actor-npc.json
+++ b/docs/examples/actor-npc.json
@@ -1,0 +1,35 @@
+{
+  "name": "Example NPC Trooper",
+  "type": "npc",
+  "img": "icons/svg/mystery-man.svg",
+  "system": {
+    "type": "troop",
+    "threatLevel": 2,
+    "faction": "Heretics",
+    "subfaction": "Cult Cell",
+    "size": 4,
+    "characteristics": {
+      "weaponSkill": { "base": 32, "advance": 0, "unnatural": 0, "damage": 0 },
+      "ballisticSkill": { "base": 35, "advance": 0, "unnatural": 0, "damage": 0 },
+      "strength": { "base": 30, "advance": 0, "unnatural": 0, "damage": 0 },
+      "toughness": { "base": 31, "advance": 0, "unnatural": 0, "damage": 0 },
+      "agility": { "base": 33, "advance": 0, "unnatural": 0, "damage": 0 },
+      "intelligence": { "base": 28, "advance": 0, "unnatural": 0, "damage": 0 },
+      "perception": { "base": 30, "advance": 0, "unnatural": 0, "damage": 0 },
+      "willpower": { "base": 29, "advance": 0, "unnatural": 0, "damage": 0 },
+      "fellowship": { "base": 25, "advance": 0, "unnatural": 0, "damage": 0 },
+      "influence": { "base": 0, "advance": 0, "unnatural": 0, "damage": 0 }
+    },
+    "skills": {
+      "awareness": { "advance": 0, "modifier": 0 },
+      "dodge": { "advance": 0, "modifier": 0 },
+      "intimidate": { "advance": 0, "modifier": 0 }
+    },
+    "wounds": { "max": 10, "value": 10 },
+    "fatigue": { "max": 8, "value": 0 },
+    "fate": { "max": 0, "value": 0 },
+    "psy": { "rating": 0, "sustained": 0, "class": "bound", "cost": 0 },
+    "experience": { "value": 0 },
+    "notes": "NPC template tuned for quick combat automation tests."
+  }
+}

--- a/docs/examples/index.html
+++ b/docs/examples/index.html
@@ -1,0 +1,99 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Examples Library — Dark Heresy 2E System Guide</title>
+    <style>
+      :root {
+        color-scheme: dark;
+        --bg: #0b0f14;
+        --panel: #111924;
+        --text: #e6edf3;
+        --muted: #9aa7b3;
+        --accent: #4db6ff;
+        --border: #1f2a36;
+      }
+      body {
+        margin: 0;
+        font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+        background: var(--bg);
+        color: var(--text);
+        line-height: 1.7;
+      }
+      header,
+      main {
+        max-width: 1100px;
+        margin: 0 auto;
+        padding: 2rem clamp(1.5rem, 4vw, 4rem);
+      }
+      header {
+        padding-top: 2.5rem;
+        border-bottom: 1px solid var(--border);
+      }
+      a {
+        color: var(--accent);
+      }
+      section {
+        background: var(--panel);
+        border: 1px solid var(--border);
+        border-radius: 1rem;
+        padding: clamp(1.25rem, 3vw, 1.75rem);
+        margin-top: 1.75rem;
+      }
+      ul {
+        margin-top: 0.5rem;
+      }
+      li {
+        margin-bottom: 0.35rem;
+      }
+      code {
+        background: rgba(77, 182, 255, 0.15);
+        border: 1px solid rgba(77, 182, 255, 0.25);
+        padding: 0.1rem 0.35rem;
+        border-radius: 0.35rem;
+      }
+      .back {
+        display: inline-block;
+        margin-top: 0.5rem;
+        color: var(--muted);
+        text-decoration: none;
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>Examples Library</h1>
+      <p>
+        Templates you can copy into JSON imports, macro scaffolding, or hand-built
+        content. These focus on the most common actor and item setups.
+      </p>
+      <a class="back" href="../index.html">← Back to guide index</a>
+    </header>
+    <main>
+      <section>
+        <h2>Actor Templates</h2>
+        <ul>
+          <li><a href="actor-acolyte.json">Acolyte actor template</a></li>
+          <li><a href="actor-npc.json">NPC actor template</a></li>
+        </ul>
+      </section>
+
+      <section>
+        <h2>Item Templates</h2>
+        <ul>
+          <li><a href="item-weapon.json">Weapon template</a></li>
+          <li><a href="item-armour.json">Armour template</a></li>
+          <li><a href="item-ammunition.json">Ammunition template</a></li>
+          <li><a href="item-gear.json">Gear template</a></li>
+          <li><a href="item-talent.json">Talent template</a></li>
+          <li><a href="item-psychic-power.json">Psychic power template</a></li>
+        </ul>
+        <p>
+          Tip: keep the <code>system</code> block aligned to keys from <code>template.json</code>
+          when expanding these.
+        </p>
+      </section>
+    </main>
+  </body>
+</html>

--- a/docs/examples/item-ammunition.json
+++ b/docs/examples/item-ammunition.json
@@ -1,0 +1,19 @@
+{
+  "name": "Example Man-Stopper Rounds",
+  "type": "ammunition",
+  "img": "icons/weapons/ammunition/bullets-cartridge-brown.webp",
+  "system": {
+    "quantity": 3,
+    "effect": {
+      "damage": { "modifier": 2, "type": "impact" },
+      "special": "Tearing",
+      "penetration": "3",
+      "attack": { "modifier": 0 }
+    },
+    "weapon": "Autogun",
+    "availability": "rare",
+    "craftsmanship": "common",
+    "weight": 0.5,
+    "description": "Ammunition template that modifies damage, pen, and qualities."
+  }
+}

--- a/docs/examples/item-armour.json
+++ b/docs/examples/item-armour.json
@@ -1,0 +1,22 @@
+{
+  "name": "Example Flak Armour",
+  "type": "armour",
+  "img": "icons/equipment/chest/breastplate-banded-steel.webp",
+  "system": {
+    "type": "basic",
+    "isAdditive": false,
+    "part": {
+      "head": 2,
+      "leftArm": 4,
+      "rightArm": 4,
+      "body": 4,
+      "leftLeg": 3,
+      "rightLeg": 3
+    },
+    "maxAgility": 45,
+    "availability": "scarce",
+    "craftsmanship": "common",
+    "weight": 11,
+    "description": "Standard armour template covering all hit locations."
+  }
+}

--- a/docs/examples/item-gear.json
+++ b/docs/examples/item-gear.json
@@ -1,0 +1,12 @@
+{
+  "name": "Example Auspex",
+  "type": "gear",
+  "img": "icons/technology/eye-monocle-visor.webp",
+  "system": {
+    "shortDescription": "Sensor suite granting bonuses to detection tasks.",
+    "availability": "rare",
+    "craftsmanship": "good",
+    "weight": 2,
+    "description": "Gear template showing the equipment fields and short description."
+  }
+}

--- a/docs/examples/item-psychic-power.json
+++ b/docs/examples/item-psychic-power.json
@@ -1,0 +1,24 @@
+{
+  "name": "Example Psychic Power: Smite",
+  "type": "psychicPower",
+  "img": "icons/magic/light/projectile-bolt-blue.webp",
+  "system": {
+    "shortDescription": "Direct damage bolt with scalable PR.",
+    "cost": 200,
+    "prerequisite": "Psy Rating 2",
+    "action": "Half Action",
+    "focusPower": { "difficulty": 0, "test": "Willpower" },
+    "range": "20m",
+    "sustained": "No",
+    "subtype": "Psychic Bolt",
+    "effect": "Deals energy damage to a single target.",
+    "damage": {
+      "zone": "bolt",
+      "type": "energy",
+      "formula": "1d10+PR",
+      "penetration": "PR",
+      "special": "Sanctified"
+    },
+    "description": "Psychic power template covering focus test and damage payload."
+  }
+}

--- a/docs/examples/item-talent.json
+++ b/docs/examples/item-talent.json
@@ -1,0 +1,14 @@
+{
+  "name": "Example Talent: Rapid Reload",
+  "type": "talent",
+  "img": "icons/skills/trades/academics-book-study-purple.webp",
+  "system": {
+    "prerequisites": "Agility 30",
+    "aptitudes": "Finesse, Fieldcraft",
+    "benefit": "Reduce reload actions by one step for applicable weapons.",
+    "tier": 1,
+    "starter": false,
+    "cost": 200,
+    "description": "Talent template aligned to template.json talent fields."
+  }
+}

--- a/docs/examples/item-weapon.json
+++ b/docs/examples/item-weapon.json
@@ -1,0 +1,23 @@
+{
+  "name": "Example Autogun",
+  "type": "weapon",
+  "img": "icons/weapons/guns/rifle-wood.webp",
+  "system": {
+    "class": "basic",
+    "type": "solid",
+    "range": 100,
+    "rateOfFire": { "single": 1, "burst": 3, "full": 6 },
+    "damage": "1d10+3",
+    "damageType": "impact",
+    "penetration": "2",
+    "clip": { "max": 30, "value": 30 },
+    "reload": "Full",
+    "special": "Reliable",
+    "attack": 0,
+    "ammo": "Autogun Magazine",
+    "availability": "common",
+    "craftsmanship": "common",
+    "weight": 4,
+    "description": "Baseline ranged weapon template with RoF and clip fields."
+  }
+}

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,170 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Dark Heresy 2E for Foundry VTT — Module Guide</title>
+    <style>
+      :root {
+        color-scheme: dark;
+        --bg: #0b0f14;
+        --panel: #111924;
+        --text: #e6edf3;
+        --muted: #9aa7b3;
+        --accent: #4db6ff;
+        --accent-strong: #7dd3ff;
+        --border: #1f2a36;
+      }
+      body {
+        margin: 0;
+        font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+        background: var(--bg);
+        color: var(--text);
+        line-height: 1.6;
+      }
+      header {
+        padding: 2.5rem clamp(1.5rem, 4vw, 4rem) 1.5rem;
+        border-bottom: 1px solid var(--border);
+        background: radial-gradient(circle at top left, rgba(77, 182, 255, 0.18), transparent 55%),
+          var(--bg);
+      }
+      main {
+        padding: 2rem clamp(1.5rem, 4vw, 4rem) 3rem;
+        display: grid;
+        gap: 2rem;
+        max-width: 1100px;
+        margin: 0 auto;
+      }
+      h1,
+      h2,
+      h3 {
+        line-height: 1.2;
+        margin-top: 0;
+      }
+      h1 {
+        font-size: clamp(2rem, 4vw, 3rem);
+        margin-bottom: 0.5rem;
+      }
+      h2 {
+        font-size: clamp(1.5rem, 3vw, 2rem);
+        margin-bottom: 0.75rem;
+      }
+      p.lead {
+        color: var(--muted);
+        max-width: 70ch;
+      }
+      nav.guide {
+        display: grid;
+        gap: 0.75rem;
+        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      }
+      nav.guide a {
+        display: block;
+        padding: 1rem 1.1rem;
+        border: 1px solid var(--border);
+        border-radius: 0.75rem;
+        text-decoration: none;
+        color: var(--text);
+        background: var(--panel);
+        transition: border-color 150ms ease, transform 150ms ease;
+      }
+      nav.guide a:hover,
+      nav.guide a:focus-visible {
+        border-color: var(--accent);
+        transform: translateY(-2px);
+        outline: none;
+      }
+      nav.guide strong {
+        color: var(--accent-strong);
+        display: block;
+        margin-bottom: 0.25rem;
+      }
+      section {
+        background: var(--panel);
+        border: 1px solid var(--border);
+        border-radius: 1rem;
+        padding: clamp(1.25rem, 3vw, 1.75rem);
+      }
+      ul {
+        margin: 0.5rem 0 0;
+        padding-left: 1.25rem;
+      }
+      code {
+        background: rgba(125, 211, 255, 0.12);
+        padding: 0.1rem 0.35rem;
+        border-radius: 0.35rem;
+        border: 1px solid rgba(125, 211, 255, 0.25);
+      }
+      footer {
+        max-width: 1100px;
+        margin: 0 auto 3rem;
+        padding: 0 clamp(1.5rem, 4vw, 4rem);
+        color: var(--muted);
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>Dark Heresy 2E System Guide</h1>
+      <p class="lead">
+        This documentation hub collects the core rules implemented by the automation,
+        highlights what parts of the module are stable versus in-flight, and provides
+        copy-paste templates you can adapt when creating new content.
+      </p>
+    </header>
+    <main>
+      <section>
+        <h2>Start Here</h2>
+        <nav class="guide" aria-label="Documentation sections">
+          <a href="rules.html">
+            <strong>Rules &amp; Mechanics</strong>
+            Attack rolls, target numbers, and multi-hit behaviour as implemented.
+          </a>
+          <a href="qualities.html">
+            <strong>Item Qualities &amp; Modifiers</strong>
+            Tearing, Proven, Primitive, Accurate, and other weapon traits.
+          </a>
+          <a href="module-status.html">
+            <strong>Module Parts &amp; Status</strong>
+            A map of major subsystems with their current implementation status.
+          </a>
+          <a href="examples/index.html">
+            <strong>Examples Library</strong>
+            Templates for actors, weapons, armour, ammunition, and more.
+          </a>
+        </nav>
+      </section>
+
+      <section>
+        <h2>Related References</h2>
+        <ul>
+          <li>
+            <a href="../RULES_REFERENCE.md">Rules Reference (source-informed)</a> —
+            the deeper reference document derived from the current automation code.
+          </li>
+          <li>
+            <a href="../FEATURE_STATUS.md">Feature Status Tracker</a> —
+            longer-form notes about implementation gaps and follow-up work.
+          </li>
+          <li>
+            <a href="../system-guide.html">Legacy System Guide</a> —
+            the original system guide retained for continuity.
+          </li>
+        </ul>
+      </section>
+
+      <section>
+        <h2>Packaging Note</h2>
+        <p>
+          Release archives are expected to follow the format <code>&lt;version&gt;.zip</code>
+          (for example, <code>0.6a.zip</code>). The builder scripts and manifest metadata have
+          been aligned to that naming convention.
+        </p>
+      </section>
+    </main>
+    <footer>
+      Maintained for the 0.4 automation push: NPC combat workflows, auto-attacks,
+      and GM-friendly tooling.
+    </footer>
+  </body>
+</html>

--- a/docs/module-status.html
+++ b/docs/module-status.html
@@ -1,0 +1,238 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Module Parts & Status — Dark Heresy 2E System Guide</title>
+    <style>
+      :root {
+        color-scheme: dark;
+        --bg: #0b0f14;
+        --panel: #111924;
+        --text: #e6edf3;
+        --muted: #9aa7b3;
+        --accent: #4db6ff;
+        --border: #1f2a36;
+        --ok: #34d399;
+        --bug: #f87171;
+        --tweak: #fbbf24;
+        --incomplete: #60a5fa;
+        --planned: #c084fc;
+      }
+      body {
+        margin: 0;
+        font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+        background: var(--bg);
+        color: var(--text);
+        line-height: 1.7;
+      }
+      header,
+      main {
+        max-width: 1150px;
+        margin: 0 auto;
+        padding: 2rem clamp(1.5rem, 4vw, 4rem);
+      }
+      header {
+        padding-top: 2.5rem;
+        border-bottom: 1px solid var(--border);
+      }
+      a {
+        color: var(--accent);
+      }
+      section {
+        background: var(--panel);
+        border: 1px solid var(--border);
+        border-radius: 1rem;
+        padding: clamp(1.25rem, 3vw, 1.75rem);
+        margin-top: 1.75rem;
+      }
+      h1,
+      h2,
+      h3 {
+        line-height: 1.2;
+        margin-top: 0;
+      }
+      h1 {
+        font-size: clamp(2rem, 4vw, 2.9rem);
+      }
+      h2 {
+        font-size: clamp(1.4rem, 3vw, 1.95rem);
+        margin-bottom: 0.6rem;
+      }
+      .legend {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.6rem 1rem;
+        margin-top: 0.75rem;
+      }
+      .legend span {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.45rem;
+        color: var(--muted);
+        font-size: 0.95rem;
+      }
+      .dot {
+        width: 0.75rem;
+        height: 0.75rem;
+        border-radius: 999px;
+        display: inline-block;
+      }
+      .ok { background: var(--ok); }
+      .bug { background: var(--bug); }
+      .tweak { background: var(--tweak); }
+      .incomplete { background: var(--incomplete); }
+      .planned { background: var(--planned); }
+      ul {
+        margin-top: 0.5rem;
+      }
+      li {
+        margin-bottom: 0.35rem;
+      }
+      strong.status {
+        font-weight: 600;
+      }
+      strong.ok { color: var(--ok); }
+      strong.bug { color: var(--bug); }
+      strong.tweak { color: var(--tweak); }
+      strong.incomplete { color: var(--incomplete); }
+      strong.planned { color: var(--planned); }
+      .back {
+        display: inline-block;
+        margin-top: 0.5rem;
+        color: var(--muted);
+        text-decoration: none;
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>Module Parts &amp; Status</h1>
+      <p>
+        A quick map of the system's major subsystems, plus the current confidence level
+        in each area.
+      </p>
+      <div class="legend" role="list" aria-label="Status legend">
+        <span role="listitem"><i class="dot ok"></i>Working As Intended</span>
+        <span role="listitem"><i class="dot bug"></i>Bugged</span>
+        <span role="listitem"><i class="dot tweak"></i>Needs Tweaking</span>
+        <span role="listitem"><i class="dot incomplete"></i>Incomplete</span>
+        <span role="listitem"><i class="dot planned"></i>Planned Feature</span>
+      </div>
+      <a class="back" href="index.html">← Back to guide index</a>
+    </header>
+    <main>
+      <section>
+        <h2>Combat Automation Core</h2>
+        <ul>
+          <li>
+            <strong class="status ok">Working As Intended:</strong> Target number calculation with aim, range,
+            rate of fire, and the ±60 modifier clamp.
+          </li>
+          <li>
+            <strong class="status ok">Working As Intended:</strong> Multi-hit resolution including Storm,
+            Twin-linked adjustments, and evasion reducing hits.
+          </li>
+          <li>
+            <strong class="status ok">Working As Intended:</strong> Hit location resolution (reverse digits)
+            and chained additional locations.
+          </li>
+          <li>
+            <strong class="status tweak">Needs Tweaking:</strong> Presentation clarity in chat cards when
+            multiple modifiers stack from traits, psychic strength, and manual edits.
+          </li>
+        </ul>
+      </section>
+
+      <section>
+        <h2>Damage &amp; Weapon Trait Handling</h2>
+        <ul>
+          <li>
+            <strong class="status ok">Working As Intended:</strong> Trait mutation pipeline for Tearing,
+            Proven, Primitive, Accurate, and related damage adjustments.
+          </li>
+          <li>
+            <strong class="status tweak">Needs Tweaking:</strong> Visibility of intermediate damage formula
+            mutations for GMs diagnosing unexpected totals.
+          </li>
+          <li>
+            <strong class="status planned">Planned Feature:</strong> Expanded trait coverage for more niche
+            qualities and situational modifiers.
+          </li>
+        </ul>
+      </section>
+
+      <section>
+        <h2>NPC Workflow &amp; Minion Support</h2>
+        <ul>
+          <li>
+            <strong class="status ok">Working As Intended:</strong> Auto-target selection helpers and range
+            modifier resolution for NPC attacks.
+          </li>
+          <li>
+            <strong class="status incomplete">Incomplete:</strong> Minion-first tooling for squads, mooks,
+            and rapid-fire GM combat flows.
+          </li>
+          <li>
+            <strong class="status planned">Planned Feature:</strong> Dark Heresy-specific automation that
+            supersedes the reference-only <code>mookAI-12-master</code> folder.
+          </li>
+        </ul>
+      </section>
+
+      <section>
+        <h2>Sheets, Derived Stats, &amp; Data Integrity</h2>
+        <ul>
+          <li>
+            <strong class="status ok">Working As Intended:</strong> Derived characteristics, skill totals,
+            armour aggregation, and critical overflow prompts.
+          </li>
+          <li>
+            <strong class="status bug">Bugged:</strong> Programmatic damage application from roll data can
+            mis-handle damage keys when piping directly into actor damage handlers.
+          </li>
+          <li>
+            <strong class="status tweak">Needs Tweaking:</strong> Guardrails and validation around manual
+            data edits that can desynchronise derived values.
+          </li>
+        </ul>
+      </section>
+
+      <section>
+        <h2>Release Tooling &amp; Packaging</h2>
+        <ul>
+          <li>
+            <strong class="status ok">Working As Intended:</strong> Release metadata generation under
+            <code>releases/&lt;tag&gt;/</code>.
+          </li>
+          <li>
+            <strong class="status ok">Working As Intended:</strong> Zip archives now follow the
+            <code>&lt;version&gt;.zip</code> convention.
+          </li>
+          <li>
+            <strong class="status planned">Planned Feature:</strong> Additional automated checks around
+            manifest consistency and version tagging.
+          </li>
+        </ul>
+      </section>
+
+      <section>
+        <h2>Documentation Surface</h2>
+        <ul>
+          <li>
+            <strong class="status ok">Working As Intended:</strong> This docs hub provides a navigable
+            index with focused pages.
+          </li>
+          <li>
+            <strong class="status incomplete">Incomplete:</strong> Examples coverage will expand alongside
+            new actor and item automation patterns.
+          </li>
+        </ul>
+        <p>
+          For the fuller status inventory, see the existing
+          <a href="../FEATURE_STATUS.md">FEATURE_STATUS.md</a> reference.
+        </p>
+      </section>
+    </main>
+  </body>
+</html>

--- a/docs/qualities.html
+++ b/docs/qualities.html
@@ -1,0 +1,151 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Item Qualities & Modifiers — Dark Heresy 2E System Guide</title>
+    <style>
+      :root {
+        color-scheme: dark;
+        --bg: #0b0f14;
+        --panel: #111924;
+        --text: #e6edf3;
+        --muted: #9aa7b3;
+        --accent: #4db6ff;
+        --border: #1f2a36;
+      }
+      body {
+        margin: 0;
+        font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+        background: var(--bg);
+        color: var(--text);
+        line-height: 1.7;
+      }
+      header,
+      main {
+        max-width: 1100px;
+        margin: 0 auto;
+        padding: 2rem clamp(1.5rem, 4vw, 4rem);
+      }
+      header {
+        padding-top: 2.5rem;
+        border-bottom: 1px solid var(--border);
+      }
+      a {
+        color: var(--accent);
+      }
+      section {
+        background: var(--panel);
+        border: 1px solid var(--border);
+        border-radius: 1rem;
+        padding: clamp(1.25rem, 3vw, 1.75rem);
+        margin-top: 1.75rem;
+      }
+      h1,
+      h2,
+      h3 {
+        line-height: 1.2;
+        margin-top: 0;
+      }
+      h1 {
+        font-size: clamp(2rem, 4vw, 2.8rem);
+      }
+      h2 {
+        font-size: clamp(1.4rem, 3vw, 1.9rem);
+        margin-bottom: 0.6rem;
+      }
+      h3 {
+        font-size: 1.1rem;
+        margin-bottom: 0.35rem;
+        color: var(--accent);
+      }
+      ul {
+        margin-top: 0.4rem;
+      }
+      .back {
+        display: inline-block;
+        margin-top: 0.5rem;
+        color: var(--muted);
+        text-decoration: none;
+      }
+      code {
+        background: rgba(77, 182, 255, 0.15);
+        border: 1px solid rgba(77, 182, 255, 0.25);
+        padding: 0.1rem 0.35rem;
+        border-radius: 0.35rem;
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>Item Qualities &amp; Modifiers</h1>
+      <p>
+        Weapon qualities are the fastest way to change outcomes. This page documents
+        the traits that currently mutate formulas or hit counts.
+      </p>
+      <a class="back" href="index.html">← Back to guide index</a>
+    </header>
+    <main>
+      <section>
+        <h2>Damage-altering Qualities</h2>
+        <h3>Tearing</h3>
+        <ul>
+          <li>Adds one extra die to the damage roll.</li>
+          <li>The lowest die is dropped (implemented via <code>dl</code>).</li>
+          <li>Only applied if the formula does not already include drop/keep syntax.</li>
+        </ul>
+
+        <h3>Proven (X)</h3>
+        <ul>
+          <li>Adds <code>minX</code> to the damage dice expression.</li>
+          <li>Dice results below X are raised to X by the dice engine.</li>
+        </ul>
+
+        <h3>Primitive (X)</h3>
+        <ul>
+          <li>Adds <code>maxX</code> to the damage dice expression.</li>
+          <li>Dice results above X are lowered to X by the dice engine.</li>
+        </ul>
+
+        <h3>Accurate</h3>
+        <ul>
+          <li>Requires aiming to activate.</li>
+          <li>Adds extra damage dice based on DoS beyond the first.</li>
+          <li>Extra dice: <code>floor((DoS - 1) / 2)</code>, capped at 2 additional dice.</li>
+        </ul>
+      </section>
+
+      <section>
+        <h2>Hit-count &amp; Targeting Qualities</h2>
+        <h3>Storm</h3>
+        <ul>
+          <li>Doubles the number of hits after the base multi-hit calculation.</li>
+        </ul>
+
+        <h3>Twin-linked</h3>
+        <ul>
+          <li>Applies a +20 bonus to hit.</li>
+          <li>When you score enough DoS, it increases hit potential and shots fired.</li>
+        </ul>
+
+        <h3>Inaccurate</h3>
+        <ul>
+          <li>Forces aim bonuses to 0 even when aiming is selected.</li>
+        </ul>
+      </section>
+
+      <section>
+        <h2>Psychic &amp; Miscellaneous Modifiers</h2>
+        <ul>
+          <li>Psychic modifiers are driven by <code>(rating - value) × 10</code>.</li>
+          <li>Attack type modifiers stack alongside manual modifiers, aim, range, and trait bonuses.</li>
+          <li>Total modifiers remain subject to the global ±60 clamp.</li>
+        </ul>
+        <p>
+          For deeper detail and code-derived notes, refer to the
+          <a href="../RULES_REFERENCE.md">Rules Reference</a> document.
+        </p>
+      </section>
+    </main>
+  </body>
+</html>

--- a/docs/rules.html
+++ b/docs/rules.html
@@ -1,0 +1,161 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Rules & Mechanics — Dark Heresy 2E System Guide</title>
+    <style>
+      :root {
+        color-scheme: dark;
+        --bg: #0b0f14;
+        --panel: #111924;
+        --text: #e6edf3;
+        --muted: #9aa7b3;
+        --accent: #4db6ff;
+        --border: #1f2a36;
+      }
+      body {
+        margin: 0;
+        font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+        background: var(--bg);
+        color: var(--text);
+        line-height: 1.7;
+      }
+      header,
+      main {
+        max-width: 1100px;
+        margin: 0 auto;
+        padding: 2rem clamp(1.5rem, 4vw, 4rem);
+      }
+      header {
+        padding-top: 2.5rem;
+        border-bottom: 1px solid var(--border);
+      }
+      a {
+        color: var(--accent);
+      }
+      section {
+        background: var(--panel);
+        border: 1px solid var(--border);
+        border-radius: 1rem;
+        padding: clamp(1.25rem, 3vw, 1.75rem);
+        margin-top: 1.75rem;
+      }
+      h1,
+      h2,
+      h3 {
+        line-height: 1.2;
+        margin-top: 0;
+      }
+      h1 {
+        font-size: clamp(2rem, 4vw, 2.8rem);
+      }
+      h2 {
+        font-size: clamp(1.4rem, 3vw, 1.9rem);
+        margin-bottom: 0.6rem;
+      }
+      h3 {
+        font-size: 1.1rem;
+        margin-bottom: 0.3rem;
+        color: var(--accent);
+      }
+      ul {
+        margin-top: 0.4rem;
+      }
+      .back {
+        display: inline-block;
+        margin-top: 0.5rem;
+        color: var(--muted);
+        text-decoration: none;
+      }
+      code {
+        background: rgba(77, 182, 255, 0.15);
+        border: 1px solid rgba(77, 182, 255, 0.25);
+        padding: 0.1rem 0.35rem;
+        border-radius: 0.35rem;
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>Rules &amp; Mechanics</h1>
+      <p>
+        This page summarises the most important mechanics as they are currently
+        implemented by the automation layer.
+      </p>
+      <a class="back" href="index.html">← Back to guide index</a>
+    </header>
+    <main>
+      <section>
+        <h2>Target Numbers &amp; Modifier Caps</h2>
+        <ul>
+          <li>Total roll modifiers are clamped to <strong>+60 / -60</strong> before being applied.</li>
+          <li>The effective target is <code>baseTarget + clamp(totalMods, -60, +60)</code>.</li>
+          <li>Combat modifiers combine aim, range, attack type, psychic rating deltas, and manual edits.</li>
+        </ul>
+        <p>
+          See the deeper notes in <a href="../RULES_REFERENCE.md">RULES_REFERENCE.md</a> for the
+          precise breakdown.
+        </p>
+      </section>
+
+      <section>
+        <h2>Attack Types &amp; Rate of Fire</h2>
+        <p>
+          Attack types drive three important values: the to-hit modifier, the degrees-of-success
+          margin required for extra hits, and the maximum number of hits.
+        </p>
+        <ul>
+          <li><strong>Standard:</strong> +10 to hit, one hit maximum.</li>
+          <li><strong>Semi-auto / Swift / Barrage:</strong> 0 modifier, extra hits every 2 DoS, capped by burst RoF.</li>
+          <li><strong>Full-auto / Lightning:</strong> -10 modifier, extra hits every 1 DoS, capped by full RoF.</li>
+          <li><strong>Called shot:</strong> -20 modifier, one hit maximum.</li>
+          <li><strong>Charge / All-out:</strong> +20 / +30, one hit maximum.</li>
+          <li><strong>Bolt / Blast:</strong> handled as single-hit attacks with custom downstream effects.</li>
+        </ul>
+      </section>
+
+      <section>
+        <h2>Degrees of Success &amp; Failure</h2>
+        <ul>
+          <li>A test succeeds when <code>d100 ≤ target.final</code>.</li>
+          <li>On success: <code>DoS = 1 + (floor(target/10) - floor(result/10))</code>.</li>
+          <li>On failure: <code>DoF = 1 + (floor(result/10) - floor(target/10))</code>.</li>
+        </ul>
+      </section>
+
+      <section>
+        <h2>Multi-hit Resolution</h2>
+        <ul>
+          <li>Base hits scale with DoS and the attack type margin.</li>
+          <li><strong>Storm</strong> doubles the hit count after the base calculation.</li>
+          <li><strong>Twin-linked</strong> can add hit potential and shots fired when you score enough DoS.</li>
+          <li>Evasion DoS subtract directly from hits.</li>
+          <li>Hits never drop below zero and are capped by RoF and remaining shots.</li>
+        </ul>
+      </section>
+
+      <section>
+        <h2>Hit Location Behaviour</h2>
+        <ul>
+          <li>The first hit location is based on the reversed roll (e.g. 05 → 50).</li>
+          <li>Additional hits follow a fixed lookup table that repeats the last entry when exhausted.</li>
+        </ul>
+      </section>
+
+      <section>
+        <h2>Damage Construction Overview</h2>
+        <ol>
+          <li>Start from the weapon's damage formula.</li>
+          <li>Apply trait mutations (such as Tearing, Proven, Primitive, Accurate).</li>
+          <li>Append flat bonuses (for example, <code>+ SB</code> or numeric modifiers).</li>
+          <li>Resolve actor bonuses and PR substitutions.</li>
+        </ol>
+        <p>
+          The dedicated <a href="qualities.html">Item Qualities &amp; Modifiers</a> page breaks down
+          how those traits are currently handled.
+        </p>
+      </section>
+    </main>
+  </body>
+</html>

--- a/releases/0.6a/release.json
+++ b/releases/0.6a/release.json
@@ -3,8 +3,8 @@
   "tag": "0.6a",
   "releaseType": "release",
   "date": "2026-01-24",
-  "manifest": "https://github.com/USBinquisition/FoundryVTT-40k/releases/download/0.6a/system.json",
-  "download": "https://github.com/USBinquisition/FoundryVTT-40k/releases/download/0.6a/0.6aUSB.zip",
+  "manifest": "https://github.com/FoundryVTT-40k/FoundryVTT-40k/releases/download/0.6a/system.json",
+  "download": "https://github.com/FoundryVTT-40k/FoundryVTT-40k/releases/download/0.6a/0.6a.zip",
   "zip": null,
   "notes": ""
 }

--- a/releases/0.6a/system.json
+++ b/releases/0.6a/system.json
@@ -104,9 +104,9 @@
   "gridUnits": "m",
   "primaryTokenAttribute": null,
   "secondaryTokenAttribute": null,
-  "url": "https://github.com/USBinquisition/FoundryVTT-40k",
+  "url": "https://github.com/FoundryVTT-40k/FoundryVTT-40k",
   "socket": true,
-  "manifest": "https://github.com/USBinquisition/FoundryVTT-40k/releases/download/0.6a/system.json",
-  "download": "https://github.com/USBinquisition/FoundryVTT-40k/releases/download/0.6a/0.6aUSB.zip",
+  "manifest": "https://github.com/FoundryVTT-40k/FoundryVTT-40k/releases/download/0.6a/system.json",
+  "download": "https://github.com/FoundryVTT-40k/FoundryVTT-40k/releases/download/0.6a/0.6a.zip",
   "license": "LICENSE.txt"
 }

--- a/scripts/release_builder.py
+++ b/scripts/release_builder.py
@@ -31,8 +31,8 @@ RELEASES_DIR = REPO_ROOT / "releases"
 BUILD_DIR = REPO_ROOT / "build"
 RELEASE_BUILD_DIR = BUILD_DIR / "release"
 
-GITHUB_REPO = "USBinquisition/FoundryVTT-40k"
-ZIP_SUFFIX = "USB.zip"
+GITHUB_REPO = "FoundryVTT-40k/FoundryVTT-40k"
+ZIP_SUFFIX = ".zip"
 VERSION_PATTERN = re.compile(r"^\d+\.\d+(?:\.\d+)?[a-zA-Z]?$", re.ASCII)
 
 

--- a/system.json
+++ b/system.json
@@ -104,9 +104,9 @@
   "gridUnits": "m",
   "primaryTokenAttribute": null,
   "secondaryTokenAttribute": null,
-  "url": "https://github.com/USBinquisition/FoundryVTT-40k",
+  "url": "https://github.com/FoundryVTT-40k/FoundryVTT-40k",
   "socket": true,
-  "manifest": "https://github.com/USBinquisition/FoundryVTT-40k/releases/download/0.6a/system.json",
-  "download": "https://github.com/USBinquisition/FoundryVTT-40k/releases/download/0.6a/0.6aUSB.zip",
+  "manifest": "https://github.com/FoundryVTT-40k/FoundryVTT-40k/releases/download/0.6a/system.json",
+  "download": "https://github.com/FoundryVTT-40k/FoundryVTT-40k/releases/download/0.6a/0.6a.zip",
   "license": "LICENSE.txt"
 }


### PR DESCRIPTION
### Motivation
- Remove USB-branded release artifact naming and repo references so releases use a plain `<version>.zip` and non-USB URLs. 
- Provide a readable, on-disk documentation hub so module behaviour, rules and templates are discoverable without digging source files. 
- Give GMs and contributors copy-paste actor/item templates to speed content creation and testing. 
- Surface current implementation status and notable caveats (e.g. damage-application key mismatch) in a single location.

### Description
- Standardised release archive naming by changing the zip suffix to `.zip` and updating the Windows pack script and builder constant in `scripts/release_builder.py` and `build/build.bat` (use of `ZIP_SUFFIX` now produces `<version>.zip`).
- Replaced USBinquisition-branded repository and artifact URLs with the new `FoundryVTT-40k/FoundryVTT-40k` paths in `system.json`, `releases/0.6a/system.json`, and `releases/0.6a/release.json` so manifests and download links point to `<version>.zip` artifacts.
- Added a documentation hub under `/docs` including `docs/index.html`, `docs/rules.html`, `docs/qualities.html`, and `docs/module-status.html` summarising combat mechanics, item qualities (including `Tearing`), and subsystem statuses.
- Added `/docs/examples` with JSON actor and item templates (`actor-acolyte.json`, `actor-npc.json`, `item-weapon.json`, `item-armour.json`, `item-ammunition.json`, `item-gear.json`, `item-talent.json`, `item-psychic-power.json`) and a navigable examples index to simplify imports and testing.

### Testing
- Ran `npm run lint` which completed successfully (exit 0) and produced warnings (no lint errors), confirming the repository still lints under the existing rules.
- Verified the builder constant `GITHUB_REPO` and `ZIP_SUFFIX` and manifest/download entries were updated to point to `FoundryVTT-40k/FoundryVTT-40k` and `<version>.zip` respectively.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974d79254348327ba56b3ccd001691b)