### PR TITLE
Stage 1.5: seed USBHub library, Oculara auth, intake tooling, and Stage 2 planning

### DIFF
--- a/40k/USBHub/docs/0.01a_plan_draft.txt
+++ b/40k/USBHub/docs/0.01a_plan_draft.txt
@@ -1,0 +1,33 @@
+USB40k 0.01a Plan Draft (Post Stage 1.5)
+=========================================
+
+Context
+-------
+Stage 1.5 seeded the localhost-only hub, library program, Oculara registries,
+and planning tooling without executing the full /40k restructure.
+
+Goals for Stage 2 (planned, not executed here)
+---------------------------------------------
+1) Restructure into canonical /40k layout first while preserving iframe navigation.
+2) Promote Dataloom authority under /40k/data/** for manifest, changelog, and integrity validation.
+3) Migrate /systems/taccog/USBHub/** into /40k/USBHub/** via a reviewed move map.
+4) Maintain public routes limited to / and /releases/ only.
+5) Preserve the two-zip/two-json release rule for usb-taccog builder outputs.
+
+Prerequisites before Stage 2 execution
+--------------------------------------
+1) Run planning and dry-run verification:
+   - python systems/taccog/USBHub/tools/stage2_move_plan.py
+   - python systems/taccog/USBHub/tools/stage2_dry_run_verify.py
+2) Run the intake scan and review text candidates:
+   - python systems/taccog/USBHub/usbhub-library/tools/library_intake_scan.py
+3) Confirm any allowlists for safe text moves.
+4) Review risk and immutables register:
+   - 40k/USBHub/docs/audit/risk_and_immutables.txt
+
+Acceptance criteria
+-------------------
+- Root /index.html remains unchanged and does not reference /40k.
+- Hub remains iframe-based with none pre-loaded.
+- Oculara localStorage keys are present and used for gating.
+- Stage 2 move plan and dry-run reports are available under /40k/USBHub/docs/.

--- a/40k/USBHub/docs/audit/cleanup_proposal.txt
+++ b/40k/USBHub/docs/audit/cleanup_proposal.txt
@@ -1,0 +1,37 @@
+Cleanup Proposal (No Deletions Performed)
+=========================================
+
+Objective
+---------
+Provide safe commands and tooling usage to review candidates before any move
+or cleanup. This proposal does NOT delete or move anything by itself.
+
+Recommended workflow
+--------------------
+1) Generate an intake scan report (default excludes /reference and /imports):
+
+   python systems/taccog/USBHub/usbhub-library/tools/library_intake_scan.py
+
+2) Review the report outputs:
+
+   systems/taccog/USBHub/data/library/intake_reports/intake_scan_report.json
+   systems/taccog/USBHub/data/library/intake_reports/intake_scan_report.txt
+
+3) Prepare a curated allowlist of text files safe to move:
+
+   # allowlist.txt (repo-relative paths; one per line)
+   docs/notes/session-01.txt
+   docs/notes/session-02.md
+
+4) Run the move script in dry-run mode first:
+
+   python systems/taccog/USBHub/usbhub-library/tools/library_intake_move.py \
+     --allowlist allowlist.txt \
+     --dry-run
+
+5) If the dry run looks correct, run the move script without --dry-run.
+
+Stage 2 planning tools (still no moves)
+---------------------------------------
+  python systems/taccog/USBHub/tools/stage2_move_plan.py
+  python systems/taccog/USBHub/tools/stage2_dry_run_verify.py

--- a/40k/USBHub/docs/audit/duplicates_report.txt
+++ b/40k/USBHub/docs/audit/duplicates_report.txt
@@ -1,0 +1,21 @@
+Duplicates Report (Stage 1.5 first pass)
+========================================
+
+Method
+------
+- Performed targeted discovery with ripgrep for USBHub-related assets.
+- Seeded new hub structure; duplicate detection focuses on newly canonicalized paths.
+
+Findings
+--------
+1) No pre-existing USBHub program duplicates were detected because the hub tree was not present.
+2) Potential future duplication risk:
+   - /40k/data/manifest.json (authority seed)
+   - /systems/taccog/USBHub/data/usb-hub-manifest.json (hub manifest)
+   These are complementary but should be kept synchronized.
+3) Intake scripts may surface duplicated text documents once the scan is run.
+
+Recommended next command
+------------------------
+Run the intake scan to produce machine-readable duplication signals:
+  python systems/taccog/USBHub/usbhub-library/tools/library_intake_scan.py

--- a/40k/USBHub/docs/audit/orphan_candidates_report.txt
+++ b/40k/USBHub/docs/audit/orphan_candidates_report.txt
@@ -1,0 +1,19 @@
+Orphan Candidates Report (Stage 1.5 first pass)
+================================================
+
+Policy
+------
+A document is considered an orphan candidate only when:
+- It is text-like (.txt, .md, .log, .rtf), and
+- It is not referenced by program code or manifests, and
+- It does not live under a protected program or immutable zone.
+
+Current state
+-------------
+- The scan report has not yet been executed in this repository context.
+- Orphan candidates will be listed in:
+  /systems/taccog/USBHub/data/library/intake_reports/intake_scan_report.json
+
+Recommended next command
+------------------------
+  python systems/taccog/USBHub/usbhub-library/tools/library_intake_scan.py

--- a/40k/USBHub/docs/audit/program_structure_suggestions.txt
+++ b/40k/USBHub/docs/audit/program_structure_suggestions.txt
@@ -1,0 +1,27 @@
+Program Structure Suggestions (Stage 1.5)
+========================================
+
+Immediate suggestions
+---------------------
+1) Keep the hub as the top frame and load all programs via iframe only when selected.
+2) Maintain "none pre-loaded" by leaving iframe src unset until the user clicks Open Program.
+3) Centralize program registration in:
+   /systems/taccog/USBHub/data/usb-programs.json
+
+Auth consolidation suggestions
+------------------------------
+1) Treat Oculara as the control plane for access levels and localStorage keys.
+2) Canonical Stage 1.5 registries:
+   /systems/taccog/USBHub/data/oclara/users.json
+   /systems/taccog/USBHub/data/oclara/profiles.json
+
+Library program structure
+-------------------------
+- index.html: bootstrap/splash + tab shell
+- library.js: bootstrap checks, gating, in-browser metadata edits + export
+- tooling handles mutation and file moves; UI stays conservative.
+
+Stage 2 direction
+-----------------
+- Use the move planning and dry-run verifier before attempting the /40k restructure.
+- Move planning scripts already emit outputs under /40k/USBHub/docs/.

--- a/40k/USBHub/docs/audit/repo_current_state.txt
+++ b/40k/USBHub/docs/audit/repo_current_state.txt
@@ -1,0 +1,35 @@
+USB40k Repo Current State Audit (Stage 1.5)
+==========================================
+
+Scan notes
+----------
+- Repository root: /workspace/FoundryVTT-40k
+- manifest.txt: NOT FOUND at repo root during audit.
+- /systems/taccog/USBHub: did not exist; created as part of Stage 1.5 bootstrap.
+- Existing repo appears to be a Foundry system layout (src/, lang/, template/, system.json, etc.).
+
+Key observations
+----------------
+1) The Stage 1.5 target hub structure was missing and has now been seeded:
+   - /systems/taccog/USBHub/index.html
+   - /systems/taccog/USBHub/data/**
+   - /systems/taccog/USBHub/usbhub-library/**
+
+2) Dataloom authority locations were missing and have now been seeded:
+   - /40k/data/paths.json
+   - /40k/data/manifest.json
+   - /40k/data/changelog/CHANGELOG_ingested.md
+
+3) There is no explicit /reference or /imports directory in this repository.
+   The intake tooling still treats them as excluded by default per policy.
+
+Immutable/risk zones observed
+-----------------------------
+- node_modules/ should be treated as immutable for Stage 1.5 automation.
+- releases/ exists and is public-route permitted but should not be mutated by intake tooling.
+- .git/ is immutable.
+
+Stage 1.5 posture
+-----------------
+This audit reflects the practical repo reality and establishes the minimum
+structures required to proceed without breaking root index.html or navigation.

--- a/40k/USBHub/docs/audit/risk_and_immutables.txt
+++ b/40k/USBHub/docs/audit/risk_and_immutables.txt
@@ -1,0 +1,19 @@
+Risk and Immutables Register (Stage 1.5)
+========================================
+
+Hard immutables
+---------------
+- Root /index.html must remain unchanged and must not link to /40k.
+- /worlds/** is immutable in automation (LevelDB sentinels, locks, logs).
+- Binary artifacts (zips, PDFs) must not be committed.
+
+Audit-informed risks in this repo
+---------------------------------
+1) manifest.txt expected by policy was not present; intake tooling reports this explicitly.
+2) The requested USBHub tree did not exist; new canonical files were seeded.
+3) This repository already has a mature Foundry system layout; aggressive intake moves could disrupt documentation.
+
+Stage 1.5 protections implemented
+---------------------------------
+- Intake tooling excludes worlds, releases, node_modules, .git, and the library program itself.
+- /reference and /imports remain excluded by default with explicit opt-in flags.

--- a/40k/USBHub/docs/audit/target_move_map.txt
+++ b/40k/USBHub/docs/audit/target_move_map.txt
@@ -1,0 +1,31 @@
+Target Move Map (Planning Only)
+==============================
+
+This move map is a planning artifact for Stage 2. No moves are executed here.
+
+Canonical mapping rules
+-----------------------
+1) Hub programs:
+   /systems/taccog/USBHub/** -> /40k/USBHub/**
+
+2) Hub data roots:
+   /systems/taccog/USBHub/data/** -> /40k/data/hub/**
+
+3) Dataloom authority:
+   /40k/data/changelog/** remains in place and is authoritative.
+
+4) Legacy catchall:
+   Any other repo-relative path -> /40k/legacy/<original-path>
+
+Immutable blockers
+------------------
+- /worlds/** (if present) must not move via automation.
+- /.git/** must not move.
+- /node_modules/** must not move.
+- /releases/** may be regenerated locally but not restructured by intake tooling.
+
+Tools
+-----
+Use:
+  python systems/taccog/USBHub/tools/stage2_move_plan.py
+  python systems/taccog/USBHub/tools/stage2_dry_run_verify.py

--- a/40k/USBHub/docs/prompt_v3_stage1_5.txt
+++ b/40k/USBHub/docs/prompt_v3_stage1_5.txt
@@ -1,0 +1,98 @@
+USB40k 0.01a Consolidation — Prompt v3 (Post Stage 1.5)
+=======================================================
+
+Stage marker
+------------
+Stage 1.5 complete in scope: library program, Oculara auth consolidation,
+hub registration, intake tooling, and Stage 2 planning scripts were created
+without executing the full restructure.
+
+Confirmed boundaries
+--------------------
+Public routes:
+  / and /releases/ only
+
+Localhost-only routes:
+  /40k/, /imports/, /reference/**
+
+Root /index.html:
+  Must remain unchanged and must not link to /40k yet.
+
+Binary artifact policy:
+  Never commit binaries in PRs. Generate locally via scripts.
+
+Implemented in Stage 1.5
+------------------------
+1) Canonical data roots seeded:
+   - /40k/data/paths.json
+   - /40k/data/manifest.json (append-only posture)
+   - /40k/data/changelog/CHANGELOG_ingested.md
+
+2) Localhost hub seeded with iframe contract preserved:
+   - /systems/taccog/USBHub/index.html
+   - /systems/taccog/USBHub/hub.css
+   - /systems/taccog/USBHub/hub.js
+   - /systems/taccog/USBHub/data/usb-programs.json
+   - /systems/taccog/USBHub/data/usb-hub-manifest.json
+   - /systems/taccog/USBHub/data/usb-manager-state.json
+   - /systems/taccog/USBHub/data/thoughts.txt
+
+3) Oculara auth consolidation (canonical Stage 1.5 registry root):
+   - /systems/taccog/USBHub/data/oclara/users.json (salted PBKDF2 hashes)
+   - /systems/taccog/USBHub/data/oclara/profiles.json
+   LocalStorage keys:
+     USB_ACTIVE_USER
+     USB_ACTIVE_PROFILE
+     USB_ACCESS_LEVEL
+
+4) Library program implemented and registered:
+   - /systems/taccog/USBHub/usbhub-library/index.html
+   - /systems/taccog/USBHub/usbhub-library/library.css
+   - /systems/taccog/USBHub/usbhub-library/library.js
+   - /systems/taccog/USBHub/usbhub-library/docs/library_usage.txt
+   - /systems/taccog/USBHub/data/library/metadata.json
+
+   Library categories include required defaults plus five additions:
+     reports, intel, books, transcriptions, other,
+     dossiers, doctrine, schematics, communiques, xenology
+
+5) Intake tooling implemented (no destructive automation):
+   - /systems/taccog/USBHub/usbhub-library/tools/library_intake_scan.py
+   - /systems/taccog/USBHub/usbhub-library/tools/library_intake_move.py
+   Default scans exclude /reference and /imports unless explicitly included.
+
+6) Stage 2 planning-only tooling implemented:
+   - /systems/taccog/USBHub/tools/stage2_move_plan.py
+   - /systems/taccog/USBHub/tools/stage2_dry_run_verify.py
+   - /40k/USBHub/docs/stage2_operator_directions.txt
+
+What remains for Stage 2+
+-------------------------
+1) Execute the restructure into /40k with move-map approval.
+2) Migrate TacCog into usb-taccog layout:
+   - /40k/USBHub/usb-taccog/systems/taccog/
+   - /40k/USBHub/usb-taccog/systems/modules/
+   - /40k/USBHub/usb-taccog/builder/
+3) Implement Dataloom as authoritative bootstrap validator and manager.
+4) Enforce public denial string for gaming 40k section in an approved stage.
+5) Ensure launcher auto-selects a free port and opens /40k/USBHub/index.html only.
+
+Release rule (non-negotiable)
+-----------------------------
+Builder outputs must be exactly:
+- system.zip + system.json
+- module.zip + module.json
+No combined bundles.
+
+Operator commands (run manually)
+--------------------------------
+Library intake scan:
+  python systems/taccog/USBHub/usbhub-library/tools/library_intake_scan.py
+
+Library intake move (dry run first):
+  python systems/taccog/USBHub/usbhub-library/tools/library_intake_move.py --allowlist allowlist.txt --dry-run
+  python systems/taccog/USBHub/usbhub-library/tools/library_intake_move.py --allowlist allowlist.txt
+
+Stage 2 move planning and verification:
+  python systems/taccog/USBHub/tools/stage2_move_plan.py
+  python systems/taccog/USBHub/tools/stage2_dry_run_verify.py

--- a/40k/USBHub/docs/stage2_dry_run_report.txt
+++ b/40k/USBHub/docs/stage2_dry_run_report.txt
@@ -1,0 +1,12 @@
+Stage 2 Dry-Run Verification
+============================
+Generated at: 2026-01-24T17:21:47.346309+00:00
+Plan source: 40k/USBHub/docs/stage2_move_plan.json
+
+Total entries: 20
+Hub entries: 20
+Immutable flagged: 0
+Destination collisions: 0
+
+Immutable examples:
+  (none flagged)

--- a/40k/USBHub/docs/stage2_move_plan.json
+++ b/40k/USBHub/docs/stage2_move_plan.json
@@ -1,0 +1,138 @@
+{
+  "generated_at": "2026-01-24T17:21:44.799138+00:00",
+  "root": "systems/taccog/USBHub",
+  "include_reference": false,
+  "include_imports": false,
+  "immutables": [
+    ".git",
+    "node_modules",
+    "releases",
+    "worlds"
+  ],
+  "plans": [
+    {
+      "source": "systems/taccog/USBHub/index.html",
+      "destination": "40k/USBHub/index.html",
+      "rule": "hub-programs-to-40k",
+      "immutable": false
+    },
+    {
+      "source": "systems/taccog/USBHub/hub.css",
+      "destination": "40k/USBHub/hub.css",
+      "rule": "hub-programs-to-40k",
+      "immutable": false
+    },
+    {
+      "source": "systems/taccog/USBHub/hub.js",
+      "destination": "40k/USBHub/hub.js",
+      "rule": "hub-programs-to-40k",
+      "immutable": false
+    },
+    {
+      "source": "systems/taccog/USBHub/tools/stage2_dry_run_verify.py",
+      "destination": "40k/USBHub/tools/stage2_dry_run_verify.py",
+      "rule": "hub-programs-to-40k",
+      "immutable": false
+    },
+    {
+      "source": "systems/taccog/USBHub/tools/stage2_move_plan.py",
+      "destination": "40k/USBHub/tools/stage2_move_plan.py",
+      "rule": "hub-programs-to-40k",
+      "immutable": false
+    },
+    {
+      "source": "systems/taccog/USBHub/usbhub-library/index.html",
+      "destination": "40k/USBHub/usbhub-library/index.html",
+      "rule": "hub-programs-to-40k",
+      "immutable": false
+    },
+    {
+      "source": "systems/taccog/USBHub/usbhub-library/library.js",
+      "destination": "40k/USBHub/usbhub-library/library.js",
+      "rule": "hub-programs-to-40k",
+      "immutable": false
+    },
+    {
+      "source": "systems/taccog/USBHub/usbhub-library/library.css",
+      "destination": "40k/USBHub/usbhub-library/library.css",
+      "rule": "hub-programs-to-40k",
+      "immutable": false
+    },
+    {
+      "source": "systems/taccog/USBHub/usbhub-library/tools/library_intake_scan.py",
+      "destination": "40k/USBHub/usbhub-library/tools/library_intake_scan.py",
+      "rule": "hub-programs-to-40k",
+      "immutable": false
+    },
+    {
+      "source": "systems/taccog/USBHub/usbhub-library/tools/library_intake_move.py",
+      "destination": "40k/USBHub/usbhub-library/tools/library_intake_move.py",
+      "rule": "hub-programs-to-40k",
+      "immutable": false
+    },
+    {
+      "source": "systems/taccog/USBHub/usbhub-library/docs/library_usage.txt",
+      "destination": "40k/USBHub/usbhub-library/docs/library_usage.txt",
+      "rule": "hub-programs-to-40k",
+      "immutable": false
+    },
+    {
+      "source": "systems/taccog/USBHub/data/usb-programs.json",
+      "destination": "40k/data/hub/usb-programs.json",
+      "rule": "hub-data-to-40k-data",
+      "immutable": false
+    },
+    {
+      "source": "systems/taccog/USBHub/data/usb-hub-manifest.json",
+      "destination": "40k/data/hub/usb-hub-manifest.json",
+      "rule": "hub-data-to-40k-data",
+      "immutable": false
+    },
+    {
+      "source": "systems/taccog/USBHub/data/thoughts.txt",
+      "destination": "40k/data/hub/thoughts.txt",
+      "rule": "hub-data-to-40k-data",
+      "immutable": false
+    },
+    {
+      "source": "systems/taccog/USBHub/data/usb-manager-state.json",
+      "destination": "40k/data/hub/usb-manager-state.json",
+      "rule": "hub-data-to-40k-data",
+      "immutable": false
+    },
+    {
+      "source": "systems/taccog/USBHub/data/library/metadata.json",
+      "destination": "40k/data/hub/library/metadata.json",
+      "rule": "hub-data-to-40k-data",
+      "immutable": false
+    },
+    {
+      "source": "systems/taccog/USBHub/data/library/intake_reports/intake_scan_report.txt",
+      "destination": "40k/data/hub/library/intake_reports/intake_scan_report.txt",
+      "rule": "hub-data-to-40k-data",
+      "immutable": false
+    },
+    {
+      "source": "systems/taccog/USBHub/data/library/intake_reports/intake_scan_report.json",
+      "destination": "40k/data/hub/library/intake_reports/intake_scan_report.json",
+      "rule": "hub-data-to-40k-data",
+      "immutable": false
+    },
+    {
+      "source": "systems/taccog/USBHub/data/oclara/users.json",
+      "destination": "40k/data/hub/oclara/users.json",
+      "rule": "hub-data-to-40k-data",
+      "immutable": false
+    },
+    {
+      "source": "systems/taccog/USBHub/data/oclara/profiles.json",
+      "destination": "40k/data/hub/oclara/profiles.json",
+      "rule": "hub-data-to-40k-data",
+      "immutable": false
+    }
+  ],
+  "notes": [
+    "This file is planning-only. No moves are performed.",
+    "Review immutable entries (worlds, releases, node_modules) before Stage 2."
+  ]
+}

--- a/40k/USBHub/docs/stage2_move_plan.txt
+++ b/40k/USBHub/docs/stage2_move_plan.txt
@@ -1,0 +1,13 @@
+Stage 2 Move Plan (Planning Only)
+================================
+Generated at: 2026-01-24T17:21:44.799138+00:00
+Include /reference: False
+Include /imports: False
+
+Counts by rule:
+  - hub-data-to-40k-data: 9
+  - hub-programs-to-40k: 11
+
+Immutable entries flagged: 0
+
+JSON output: 40k/USBHub/docs/stage2_move_plan.json

--- a/40k/USBHub/docs/stage2_operator_directions.txt
+++ b/40k/USBHub/docs/stage2_operator_directions.txt
@@ -1,0 +1,61 @@
+Stage 2 Operator Directions (Planning & Approval Workflow)
+==========================================================
+
+Purpose
+-------
+Provide a safe, review-first workflow for Stage 2 restructuring into /40k.
+No restructure is executed automatically by these directions.
+
+Step 1 — Generate the move plan
+-------------------------------
+Command:
+  python systems/taccog/USBHub/tools/stage2_move_plan.py
+
+Optional inclusions:
+  python systems/taccog/USBHub/tools/stage2_move_plan.py --include-reference --include-imports
+
+Outputs:
+  40k/USBHub/docs/stage2_move_plan.json
+  40k/USBHub/docs/stage2_move_plan.txt
+
+Step 2 — Verify the move plan
+-----------------------------
+Command:
+  python systems/taccog/USBHub/tools/stage2_dry_run_verify.py
+
+Output:
+  40k/USBHub/docs/stage2_dry_run_report.txt
+
+Review checklist
+----------------
+1) Confirm immutable paths (worlds, releases, node_modules, .git) are flagged.
+2) Check for destination collisions in stage2_dry_run_report.txt.
+3) Ensure hub files map to /40k/USBHub/** and hub data maps to /40k/data/hub/**.
+
+Step 3 — Library intake review (before any moves)
+-------------------------------------------------
+Command:
+  python systems/taccog/USBHub/usbhub-library/tools/library_intake_scan.py
+
+Outputs:
+  systems/taccog/USBHub/data/library/intake_reports/intake_scan_report.json
+  systems/taccog/USBHub/data/library/intake_reports/intake_scan_report.txt
+
+Step 4 — Approve any safe text moves explicitly
+------------------------------------------------
+Prepare allowlist.txt (one repo-relative path per line), then:
+
+Dry run:
+  python systems/taccog/USBHub/usbhub-library/tools/library_intake_move.py --allowlist allowlist.txt --dry-run
+
+Execute:
+  python systems/taccog/USBHub/usbhub-library/tools/library_intake_move.py --allowlist allowlist.txt
+
+Backups are created under:
+  systems/taccog/USBHub/data/library/_backups/<timestamp>/
+
+Non-negotiables
+---------------
+- Do not touch /worlds/** via automation.
+- Do not commit PDFs or zip outputs.
+- Do not change root /index.html.

--- a/40k/data/changelog/CHANGELOG_ingested.md
+++ b/40k/data/changelog/CHANGELOG_ingested.md
@@ -1,0 +1,16 @@
+# Ingested CHANGELOG.md (Stage 1.5)
+
+# Changelog
+
+This project keeps a human-readable changelog focused on the 0.4 release line described in `AGENTS.md`.
+
+## [0.6a] - 2026-01-24
+
+### Changed
+- Replaced the legacy PowerShell and batch release packaging flow with a single Python release builder that supports both CLI and GUI usage.
+- Standardized release outputs into a repo-local `releases/` folder with per-version metadata and a copy of the release manifest.
+- Updated `system.json` to point at the new `0.6a` release manifest and download URLs.
+
+### Notes
+- The `0.5.x` line is considered scrapped; `0.6a` is the new clean starting point for future releases.
+- Changelog enforcement can be run in `strict`, `warn`, or `off` mode via the new release builder.

--- a/40k/data/manifest.json
+++ b/40k/data/manifest.json
@@ -1,0 +1,31 @@
+{
+  "version": "0.01a",
+  "generated_by": "stage1.5-bootstrap",
+  "inventory": [
+    "40k/data/paths.json",
+    "40k/data/changelog/CHANGELOG_ingested.md",
+    "systems/taccog/USBHub/index.html",
+    "systems/taccog/USBHub/hub.css",
+    "systems/taccog/USBHub/hub.js",
+    "systems/taccog/USBHub/data/usb-programs.json",
+    "systems/taccog/USBHub/data/usb-hub-manifest.json",
+    "systems/taccog/USBHub/data/usb-manager-state.json",
+    "systems/taccog/USBHub/data/oclara/users.json",
+    "systems/taccog/USBHub/data/oclara/profiles.json",
+    "systems/taccog/USBHub/usbhub-library/index.html",
+    "systems/taccog/USBHub/usbhub-library/library.css",
+    "systems/taccog/USBHub/usbhub-library/library.js",
+    "systems/taccog/USBHub/usbhub-library/docs/library_usage.txt",
+    "systems/taccog/USBHub/usbhub-library/tools/library_intake_scan.py",
+    "systems/taccog/USBHub/usbhub-library/tools/library_intake_move.py",
+    "systems/taccog/USBHub/tools/stage2_move_plan.py",
+    "systems/taccog/USBHub/tools/stage2_dry_run_verify.py",
+    "40k/USBHub/docs/0.01a_plan_draft.txt",
+    "40k/USBHub/docs/stage2_operator_directions.txt",
+    "40k/USBHub/docs/prompt_v3_stage1_5.txt"
+  ],
+  "integrity_notes": [
+    "This manifest is append-only for Stage 1.5. Update by merging new entries rather than overwriting.",
+    "Use systems/taccog/USBHub/tools/stage2_dry_run_verify.py to validate plan integrity before Stage 2."
+  ]
+}

--- a/40k/data/paths.json
+++ b/40k/data/paths.json
@@ -1,0 +1,19 @@
+{
+  "version": "0.01a",
+  "description": "Canonical data root mapping for USB40k localhost-only hub.",
+  "data_root": "/40k/data",
+  "hub_root": "/systems/taccog/USBHub",
+  "library_root": "/systems/taccog/USBHub/data/library",
+  "oclara_root": "/systems/taccog/USBHub/data/oclara",
+  "changelog_root": "/40k/data/changelog",
+  "public_routes": ["/", "/releases/"],
+  "localhost_only_routes": ["/40k/", "/imports/", "/reference/**"],
+  "scan_defaults": {
+    "exclude": ["/reference", "/imports"],
+    "include_opt_in": ["/reference", "/imports"]
+  },
+  "notes": [
+    "Root /index.html must remain unchanged and must not link to /40k yet.",
+    "No binary artifacts should be committed; use scripts to generate local outputs."
+  ]
+}

--- a/systems/taccog/USBHub/data/library/intake_reports/intake_scan_report.json
+++ b/systems/taccog/USBHub/data/library/intake_reports/intake_scan_report.json
@@ -1,0 +1,60 @@
+{
+  "version": "0.01a",
+  "generated_at": "2026-01-24T17:21:39.059635+00:00",
+  "scan_root": "systems/taccog/USBHub",
+  "defaults": {
+    "exclude_reference": true,
+    "exclude_imports": true
+  },
+  "manifest_txt_present": false,
+  "text_candidates": [
+    {
+      "path": "systems/taccog/USBHub/data/library/intake_reports/intake_scan_report.txt",
+      "ext": ".txt",
+      "size": 13458,
+      "used_reference_hits": 1,
+      "used_reference_examples": [
+        "systems/taccog/USBHub/usbhub-library/tools/library_intake_scan.py"
+      ],
+      "protected": true,
+      "safe_to_move": false,
+      "reason": "protected-zone"
+    },
+    {
+      "path": "systems/taccog/USBHub/data/thoughts.txt",
+      "ext": ".txt",
+      "size": 124,
+      "used_reference_hits": 2,
+      "used_reference_examples": [
+        "systems/taccog/USBHub/hub.js",
+        "systems/taccog/USBHub/data/library/intake_reports/intake_scan_report.json"
+      ],
+      "protected": false,
+      "safe_to_move": false,
+      "reason": "referenced-by-program"
+    },
+    {
+      "path": "systems/taccog/USBHub/usbhub-library/docs/library_usage.txt",
+      "ext": ".txt",
+      "size": 2143,
+      "used_reference_hits": 1,
+      "used_reference_examples": [
+        "systems/taccog/USBHub/data/library/intake_reports/intake_scan_report.json"
+      ],
+      "protected": true,
+      "safe_to_move": false,
+      "reason": "protected-zone"
+    }
+  ],
+  "pdf_candidates": [],
+  "summary": {
+    "text_total": 3,
+    "text_safe_to_move": 0,
+    "pdf_total": 0,
+    "pdf_reference_only": 0
+  },
+  "notes": [
+    "This scan is conservative: any filename hit in code marks a file as referenced.",
+    "PDFs are indexed only; binaries must not be committed."
+  ]
+}

--- a/systems/taccog/USBHub/data/library/intake_reports/intake_scan_report.txt
+++ b/systems/taccog/USBHub/data/library/intake_reports/intake_scan_report.txt
@@ -1,0 +1,25 @@
+USBL Library Intake Scan Report
+===============================
+Generated at: 2026-01-24T17:21:39.059635+00:00
+Scan root: systems/taccog/USBHub
+
+Defaults:
+  exclude /reference: True
+  exclude /imports: True
+  manifest.txt present: False
+
+Summary:
+  Text candidates: 3
+  Safe-to-move text candidates: 0
+  PDF candidates (reference-only): 0
+
+Safe-to-move text candidates:
+  (none detected)
+
+Blocked or referenced text candidates:
+  - systems/taccog/USBHub/usbhub-library/docs/library_usage.txt (protected-zone)
+  - systems/taccog/USBHub/data/thoughts.txt (referenced-by-program)
+  - systems/taccog/USBHub/data/library/intake_reports/intake_scan_report.txt (protected-zone)
+
+PDF references:
+  (none detected)

--- a/systems/taccog/USBHub/data/library/metadata.json
+++ b/systems/taccog/USBHub/data/library/metadata.json
@@ -1,0 +1,61 @@
+{
+  "version": "0.01a",
+  "categories": [
+    "reports",
+    "intel",
+    "books",
+    "transcriptions",
+    "other",
+    "dossiers",
+    "doctrine",
+    "schematics",
+    "communiques",
+    "xenology"
+  ],
+  "items": [
+    {
+      "id": "txt-changelog-ingested",
+      "title": "FoundryVTT-40k CHANGELOG (Ingested)",
+      "type": "txt",
+      "category": "reports",
+      "path": "/40k/data/changelog/CHANGELOG_ingested.md",
+      "tags": ["changelog", "dataloom", "ingested"],
+      "created_at": "2026-01-24T00:00:00Z",
+      "updated_at": "2026-01-24T00:00:00Z",
+      "source": "intake-script",
+      "notes": "Stage 1.5 ingestion of legacy CHANGELOG.md into Dataloom authority.",
+      "hash": null,
+      "status": "active"
+    },
+    {
+      "id": "link-pdf-reference-policy",
+      "title": "PDF Reference Policy (Remote)",
+      "type": "link",
+      "category": "doctrine",
+      "url": "https://example.com/usb40k/pdf-policy",
+      "tags": ["pdf", "policy", "link"],
+      "created_at": "2026-01-24T00:00:00Z",
+      "updated_at": "2026-01-24T00:00:00Z",
+      "source": "manual",
+      "notes": "Replace with a real remote PDF link (e.g., Google Drive share URL).",
+      "hash": null,
+      "status": "active"
+    }
+  ],
+  "schema_notes": {
+    "required_fields": [
+      "id",
+      "title",
+      "type",
+      "category",
+      "tags",
+      "created_at",
+      "updated_at",
+      "source",
+      "notes",
+      "status"
+    ],
+    "path_or_url_rule": "Local items use path; remote items use url.",
+    "hashing": "sha256 preferred for local text items."
+  }
+}

--- a/systems/taccog/USBHub/data/oclara/profiles.json
+++ b/systems/taccog/USBHub/data/oclara/profiles.json
@@ -1,0 +1,45 @@
+{
+  "version": "0.01a",
+  "canonical_path": "/systems/taccog/USBHub/data/oclara/profiles.json",
+  "profiles": [
+    {
+      "user": "Zeheve",
+      "access_level": "viewer",
+      "characters": ["Umlaut (Heretic)", "Laufey (Rogue Trader)"]
+    },
+    {
+      "user": "Jem",
+      "access_level": "viewer",
+      "characters": ["Himeraos (Heretic)", "Lupaster (Rogue Trader)"]
+    },
+    {
+      "user": "Bost",
+      "access_level": "viewer",
+      "characters": ["Vlad (Rogue Trader)"]
+    },
+    {
+      "user": "Sela",
+      "access_level": "viewer",
+      "characters": ["Teja (Rogue Trader)", "Rob (Rogue Trader)", "AXM-13", "Qetesh", "Herran Eta-8 (Inquisition)", "Necaladun (Game Master)"]
+    },
+    {
+      "user": "None",
+      "access_level": "viewer",
+      "characters": ["Malcador (Redacted Profile)"]
+    },
+    {
+      "user": "Jules",
+      "access_level": "viewer",
+      "characters": ["Sola (Inquisition)"]
+    },
+    {
+      "user": "Dryden",
+      "access_level": "viewer",
+      "characters": ["Wolfgang (Inquisition)"]
+    }
+  ],
+  "notes": [
+    "Unknown legacy registry paths; this file is the Stage 1.5 canonical profile registry under Oculara.",
+    "Access levels follow the viewer/operator/admin/root model."
+  ]
+}

--- a/systems/taccog/USBHub/data/oclara/users.json
+++ b/systems/taccog/USBHub/data/oclara/users.json
@@ -1,0 +1,42 @@
+{
+  "version": "0.01a",
+  "password_hashing": {
+    "algorithm": "PBKDF2-HMAC-SHA256",
+    "iterations": 200000,
+    "encoding": "base64"
+  },
+  "users": [
+    {
+      "username": "guest",
+      "access_level": "viewer",
+      "default_profile": "guest",
+      "salt_b64": "bdemXd4QhuMMUD72392D8w==",
+      "hash_b64": "sZbCDsriDp0CwGC+s2nQz5n+TJXcGMGzirAhOu9+4sg=",
+      "notes": "Viewer-only guest access."
+    },
+    {
+      "username": "operator",
+      "access_level": "operator",
+      "default_profile": "operator",
+      "salt_b64": "gdrzOmv04tiQi5DCxbs5AQ==",
+      "hash_b64": "igY1u+c1vLuk6HekDTOASdWi7J55yxJMMdK+KmDZU/A=",
+      "notes": "Operator role for document intake and edits."
+    },
+    {
+      "username": "Necaladun",
+      "access_level": "admin",
+      "default_profile": "Necaladun",
+      "salt_b64": "VoZGqmtjt+yGKG8p0Mbblw==",
+      "hash_b64": "S+Sa7U1l9pM0eQn7KOlv8UTD37BwQcWZU0fYct1H0Fw=",
+      "notes": "Primary admin account."
+    },
+    {
+      "username": "root",
+      "access_level": "root",
+      "default_profile": "root",
+      "salt_b64": "Vxy/og14h3TWVuByHR+udg==",
+      "hash_b64": "u+im/bxQIuvpEMJ9ZhFkgtLWyQZ+CcaRF8qOf0ner7U=",
+      "notes": "Root account; password is admin."
+    }
+  ]
+}

--- a/systems/taccog/USBHub/data/thoughts.txt
+++ b/systems/taccog/USBHub/data/thoughts.txt
@@ -1,0 +1,3 @@
+Knowledge is the blade that never dulls.
+Trust is earned in drops and lost in floods.
+Only the prepared deserve to survive.

--- a/systems/taccog/USBHub/data/usb-hub-manifest.json
+++ b/systems/taccog/USBHub/data/usb-hub-manifest.json
@@ -1,0 +1,27 @@
+{
+  "version": "0.01a",
+  "name": "USB40k Localhost Hub",
+  "iframe_contract": {
+    "layers": 3,
+    "none_preloaded": true,
+    "top_frame": "systems/taccog/USBHub/index.html",
+    "program_frame": "iframe#programFrame"
+  },
+  "routing": {
+    "public_routes": ["/", "/releases/"],
+    "localhost_only_routes": ["/40k/", "/imports/", "/reference/**"],
+    "root_index_html_mutation": "forbidden"
+  },
+  "auth": {
+    "provider": "oclara",
+    "local_storage_keys": [
+      "USB_ACTIVE_USER",
+      "USB_ACTIVE_PROFILE",
+      "USB_ACCESS_LEVEL"
+    ]
+  },
+  "notes": [
+    "Programs must remain framed to preserve navigation model.",
+    "Do not commit binary artifacts; generate locally via tooling."
+  ]
+}

--- a/systems/taccog/USBHub/data/usb-manager-state.json
+++ b/systems/taccog/USBHub/data/usb-manager-state.json
@@ -1,0 +1,15 @@
+{
+  "version": "0.01a",
+  "last_bootstrap": "2026-01-24T17:21:49Z",
+  "last_intake_scan": "2026-01-24T17:21:49Z",
+  "last_intake_move": null,
+  "stage_markers": {
+    "stage1_complete": true,
+    "stage1_5_complete": true,
+    "stage2_ready": false
+  },
+  "notes": [
+    "Update this file via scripts rather than manual edits when possible.",
+    "World data and LevelDB sentinels remain immutable."
+  ]
+}

--- a/systems/taccog/USBHub/data/usb-programs.json
+++ b/systems/taccog/USBHub/data/usb-programs.json
@@ -1,0 +1,13 @@
+{
+  "version": "0.01a",
+  "programs": [
+    {
+      "id": "usbhub-library",
+      "title": "USBL Library",
+      "path": "./usbhub-library/index.html",
+      "min_access": "viewer",
+      "description": "Archivum intake, cataloging, and reading tools for text and PDF references.",
+      "tags": ["library", "intake", "documents", "pdf"]
+    }
+  ]
+}

--- a/systems/taccog/USBHub/hub.css
+++ b/systems/taccog/USBHub/hub.css
@@ -1,0 +1,174 @@
+:root {
+  --crt-bg: #05070a;
+  --crt-panel: rgba(14, 26, 31, 0.92);
+  --crt-border: #2be3ff;
+  --crt-text: #d7f7ff;
+  --crt-dim: #7fb7c3;
+  --crt-accent: #ff4d6d;
+  --crt-warn: #ffcc66;
+  font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(circle at top, rgba(43, 227, 255, 0.08), transparent 60%), var(--crt-bg);
+  color: var(--crt-text);
+}
+
+.hub {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 1.5rem clamp(1rem, 2vw, 2.5rem) 2.5rem;
+  display: grid;
+  gap: 1.25rem;
+}
+
+.hub__header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1.25rem;
+  border: 1px solid rgba(43, 227, 255, 0.35);
+  background: var(--crt-panel);
+  box-shadow: 0 0 0 1px rgba(43, 227, 255, 0.12), inset 0 0 40px rgba(43, 227, 255, 0.06);
+}
+
+.hub__title h1 {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.04em;
+}
+
+.hub__subtitle {
+  margin: 0;
+  color: var(--crt-dim);
+}
+
+.hub__status {
+  min-width: 260px;
+  padding: 0.75rem 1rem;
+  border: 1px dashed rgba(43, 227, 255, 0.5);
+  background: rgba(8, 20, 26, 0.8);
+  color: var(--crt-dim);
+}
+
+.hub__auth,
+.hub__programs,
+.hub__frame,
+.hub__footer {
+  border: 1px solid rgba(43, 227, 255, 0.3);
+  background: var(--crt-panel);
+  padding: 1.1rem 1.25rem;
+}
+
+.auth__form,
+.programs__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem 1rem;
+  align-items: end;
+}
+
+.auth__field,
+.programs__field {
+  display: grid;
+  gap: 0.35rem;
+  min-width: 220px;
+}
+
+input,
+select,
+button {
+  font: inherit;
+}
+
+input,
+select {
+  padding: 0.5rem 0.6rem;
+  border: 1px solid rgba(43, 227, 255, 0.45);
+  background: rgba(4, 12, 16, 0.9);
+  color: var(--crt-text);
+}
+
+input:focus,
+select:focus {
+  outline: 2px solid rgba(43, 227, 255, 0.45);
+  outline-offset: 1px;
+}
+
+.btn {
+  padding: 0.55rem 1rem;
+  border: 1px solid rgba(43, 227, 255, 0.65);
+  background: linear-gradient(180deg, rgba(43, 227, 255, 0.2), rgba(43, 227, 255, 0.06));
+  color: var(--crt-text);
+  cursor: pointer;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.btn:hover {
+  border-color: var(--crt-border);
+  box-shadow: 0 0 12px rgba(43, 227, 255, 0.25);
+}
+
+.btn--ghost {
+  border-style: dashed;
+  background: transparent;
+}
+
+.auth__active,
+.programs__hint,
+.programs__meta {
+  margin-top: 0.75rem;
+  color: var(--crt-dim);
+}
+
+.programs__meta {
+  border-top: 1px dashed rgba(43, 227, 255, 0.25);
+  padding-top: 0.75rem;
+}
+
+.hub__frame {
+  padding: 0.75rem;
+}
+
+#programFrame {
+  width: 100%;
+  min-height: 65vh;
+  border: 1px solid rgba(43, 227, 255, 0.45);
+  background: rgba(2, 6, 8, 0.9);
+}
+
+.hub__footer {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.thought {
+  color: var(--crt-warn);
+}
+
+.date {
+  color: var(--crt-dim);
+  font-variant-numeric: tabular-nums;
+}
+
+.status--ok {
+  color: #7dffb6;
+}
+
+.status--warn {
+  color: var(--crt-warn);
+}
+
+.status--err {
+  color: var(--crt-accent);
+}

--- a/systems/taccog/USBHub/hub.js
+++ b/systems/taccog/USBHub/hub.js
@@ -1,0 +1,242 @@
+const STORAGE_KEYS = {
+  user: "USB_ACTIVE_USER",
+  profile: "USB_ACTIVE_PROFILE",
+  access: "USB_ACCESS_LEVEL",
+};
+
+const ACCESS_LEVELS = ["viewer", "operator", "admin", "root"];
+const ACCESS_RANK = new Map(ACCESS_LEVELS.map((level, idx) => [level, idx]));
+
+const hubStatus = document.getElementById("hubStatus");
+const loginForm = document.getElementById("loginForm");
+const logoutBtn = document.getElementById("logoutBtn");
+const activeUser = document.getElementById("activeUser");
+const programSelect = document.getElementById("programSelect");
+const loadProgramBtn = document.getElementById("loadProgramBtn");
+const programMeta = document.getElementById("programMeta");
+const programFrame = document.getElementById("programFrame");
+const thoughtOfDay = document.getElementById("thoughtOfDay");
+const imperialDate = document.getElementById("imperialDate");
+
+let usersRegistry = null;
+let programsRegistry = [];
+
+function setStatus(message, tone = "ok") {
+  hubStatus.textContent = message;
+  hubStatus.classList.remove("status--ok", "status--warn", "status--err");
+  hubStatus.classList.add(`status--${tone}`);
+}
+
+function currentAccessLevel() {
+  const stored = localStorage.getItem(STORAGE_KEYS.access);
+  return ACCESS_RANK.has(stored) ? stored : "viewer";
+}
+
+function currentAccessRank() {
+  return ACCESS_RANK.get(currentAccessLevel()) ?? 0;
+}
+
+function setActiveUserDisplay() {
+  const user = localStorage.getItem(STORAGE_KEYS.user) ?? "guest";
+  const profile = localStorage.getItem(STORAGE_KEYS.profile) ?? "default";
+  const access = currentAccessLevel();
+  activeUser.textContent = `Active user: ${user} | Profile: ${profile} | Access: ${access}`;
+}
+
+async function loadThoughtOfDay() {
+  try {
+    const resp = await fetch("./data/thoughts.txt", { cache: "no-store" });
+    if (!resp.ok) throw new Error(`thoughts.txt ${resp.status}`);
+    const text = await resp.text();
+    const lines = text
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean);
+    thoughtOfDay.textContent = lines[0] ? `Thought of the Day: ${lines[0]}` : "Thought of the Day: Vigilance is victory.";
+  } catch (err) {
+    thoughtOfDay.textContent = "Thought of the Day: Vigilance is victory.";
+    console.warn("Unable to load thoughts.txt", err);
+  }
+}
+
+function renderImperialDate(now = new Date()) {
+  const year = now.getUTCFullYear();
+  const start = Date.UTC(year, 0, 1);
+  const end = Date.UTC(year + 1, 0, 1);
+  const fraction = Math.min(999, Math.floor(((now.getTime() - start) / (end - start)) * 1000));
+  const millennium = Math.floor(year / 1000) + 1;
+  const yearWithinMillennium = year % 1000;
+  const checkNumber = 0;
+  const formatted = `${checkNumber}.${String(fraction).padStart(3, "0")}.${String(yearWithinMillennium).padStart(3, "0")}.M${millennium}`;
+  imperialDate.textContent = `Imperial Date: ${formatted}`;
+}
+
+async function loadUsersRegistry() {
+  const resp = await fetch("./data/oclara/users.json", { cache: "no-store" });
+  if (!resp.ok) throw new Error(`users registry ${resp.status}`);
+  usersRegistry = await resp.json();
+  return usersRegistry;
+}
+
+async function pbkdf2Hash(password, salt, iterations) {
+  const enc = new TextEncoder();
+  const keyMaterial = await crypto.subtle.importKey("raw", enc.encode(password), "PBKDF2", false, ["deriveBits"]);
+  const bits = await crypto.subtle.deriveBits(
+    {
+      name: "PBKDF2",
+      salt: Uint8Array.from(atob(salt), (c) => c.charCodeAt(0)),
+      iterations,
+      hash: "SHA-256",
+    },
+    keyMaterial,
+    256,
+  );
+  const bytes = new Uint8Array(bits);
+  let binary = "";
+  bytes.forEach((b) => {
+    binary += String.fromCharCode(b);
+  });
+  return btoa(binary);
+}
+
+async function verifyPassword(userRecord, password) {
+  const derived = await pbkdf2Hash(password, userRecord.salt_b64, userRecord.iterations);
+  return derived === userRecord.hash_b64;
+}
+
+function programAllowed(program) {
+  const neededRank = ACCESS_RANK.get(program.min_access ?? "viewer") ?? 0;
+  return currentAccessRank() >= neededRank;
+}
+
+function describeProgram(program) {
+  const tags = (program.tags ?? []).join(", ");
+  return [
+    `<strong>${program.title}</strong>`,
+    program.description ?? "No description provided.",
+    `Minimum access: ${program.min_access ?? "viewer"}`,
+    tags ? `Tags: ${tags}` : "",
+  ]
+    .filter(Boolean)
+    .join("<br />");
+}
+
+function populateProgramSelect() {
+  programSelect.innerHTML = "";
+  const allowedPrograms = programsRegistry.filter(programAllowed);
+  if (!allowedPrograms.length) {
+    const opt = document.createElement("option");
+    opt.value = "";
+    opt.textContent = "No programs available for current access level";
+    programSelect.appendChild(opt);
+    programMeta.innerHTML = "";
+    return;
+  }
+
+  allowedPrograms.forEach((program, idx) => {
+    const opt = document.createElement("option");
+    opt.value = program.path;
+    opt.textContent = program.title;
+    opt.dataset.index = String(idx);
+    programSelect.appendChild(opt);
+  });
+  programSelect.selectedIndex = 0;
+  programMeta.innerHTML = describeProgram(allowedPrograms[0]);
+
+  programSelect.addEventListener("change", () => {
+    const selected = allowedPrograms[programSelect.selectedIndex];
+    if (selected) {
+      programMeta.innerHTML = describeProgram(selected);
+    }
+  });
+}
+
+async function loadProgramsRegistry() {
+  const resp = await fetch("./data/usb-programs.json", { cache: "no-store" });
+  if (!resp.ok) throw new Error(`program registry ${resp.status}`);
+  const data = await resp.json();
+  programsRegistry = data.programs ?? [];
+  populateProgramSelect();
+}
+
+async function handleLogin(event) {
+  event.preventDefault();
+  const formData = new FormData(loginForm);
+  const username = String(formData.get("username") ?? "").trim();
+  const password = String(formData.get("password") ?? "");
+
+  if (!username || !password) {
+    setStatus("Provide both username and password.", "warn");
+    return;
+  }
+
+  const userRecord = usersRegistry?.users?.find((user) => user.username === username);
+  if (!userRecord) {
+    setStatus("Unknown user.", "err");
+    return;
+  }
+
+  const ok = await verifyPassword(userRecord, password);
+  if (!ok) {
+    setStatus("Access denied.", "err");
+    return;
+  }
+
+  localStorage.setItem(STORAGE_KEYS.user, userRecord.username);
+  localStorage.setItem(STORAGE_KEYS.profile, userRecord.default_profile ?? userRecord.username);
+  localStorage.setItem(STORAGE_KEYS.access, userRecord.access_level);
+
+  setActiveUserDisplay();
+  populateProgramSelect();
+  setStatus(`Access granted for ${userRecord.username}.`, "ok");
+}
+
+function handleLogout() {
+  localStorage.setItem(STORAGE_KEYS.user, "guest");
+  localStorage.setItem(STORAGE_KEYS.profile, "guest");
+  localStorage.setItem(STORAGE_KEYS.access, "viewer");
+  programFrame.removeAttribute("src");
+  setActiveUserDisplay();
+  populateProgramSelect();
+  setStatus("Logged out to guest viewer.", "warn");
+}
+
+function openProgram() {
+  const selectedPath = programSelect.value;
+  const program = programsRegistry.find((entry) => entry.path === selectedPath);
+  if (!program) {
+    setStatus("Select a valid program first.", "warn");
+    return;
+  }
+  if (!programAllowed(program)) {
+    setStatus("Current user lacks the required access level.", "err");
+    return;
+  }
+  programFrame.src = program.path;
+  setStatus(`Loaded ${program.title}.`, "ok");
+}
+
+async function bootstrap() {
+  setStatus("Bootstrapping hub registries...", "warn");
+  try {
+    await loadUsersRegistry();
+    await loadProgramsRegistry();
+    renderImperialDate();
+    loadThoughtOfDay();
+    setActiveUserDisplay();
+    setStatus("Hub online. Choose a program to begin.", "ok");
+  } catch (err) {
+    console.error(err);
+    setStatus("Hub bootstrap failed. Check registries and paths.", "err");
+  }
+}
+
+loginForm.addEventListener("submit", handleLogin);
+logoutBtn.addEventListener("click", handleLogout);
+loadProgramBtn.addEventListener("click", openProgram);
+
+if (!localStorage.getItem(STORAGE_KEYS.user)) {
+  handleLogout();
+}
+
+bootstrap();

--- a/systems/taccog/USBHub/index.html
+++ b/systems/taccog/USBHub/index.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>USB40k Hub (Localhost Only)</title>
+    <link rel="stylesheet" href="./hub.css" />
+  </head>
+  <body>
+    <div class="hub">
+      <header class="hub__header">
+        <div class="hub__title">
+          <h1>USB40k Command Hub</h1>
+          <p class="hub__subtitle">Localhost-only control plane. Nothing loads until you choose.</p>
+        </div>
+        <div class="hub__status" id="hubStatus" role="status" aria-live="polite"></div>
+      </header>
+
+      <section class="hub__auth" aria-labelledby="authHeading">
+        <h2 id="authHeading">Oculara Access Control</h2>
+        <form id="loginForm" class="auth__form">
+          <label class="auth__field">
+            <span>Username</span>
+            <input id="username" name="username" autocomplete="username" required />
+          </label>
+          <label class="auth__field">
+            <span>Password</span>
+            <input id="password" name="password" type="password" autocomplete="current-password" required />
+          </label>
+          <div class="auth__actions">
+            <button type="submit" class="btn">Login</button>
+            <button type="button" id="logoutBtn" class="btn btn--ghost">Logout</button>
+          </div>
+        </form>
+        <div class="auth__active" id="activeUser"></div>
+      </section>
+
+      <section class="hub__programs" aria-labelledby="programHeading">
+        <h2 id="programHeading">Programs</h2>
+        <div class="programs__controls">
+          <label class="programs__field">
+            <span>Program</span>
+            <select id="programSelect"></select>
+          </label>
+          <button type="button" id="loadProgramBtn" class="btn">Open Program</button>
+        </div>
+        <p class="programs__hint">
+          Programs run inside the hub frame. The iframe stays blank until you explicitly open a program.
+        </p>
+        <div class="programs__meta" id="programMeta"></div>
+      </section>
+
+      <section class="hub__frame" aria-label="Program frame">
+        <iframe id="programFrame" title="USB40k Program Frame" sandbox="allow-scripts allow-same-origin allow-forms allow-downloads"></iframe>
+      </section>
+
+      <footer class="hub__footer">
+        <div id="thoughtOfDay" class="thought"></div>
+        <div id="imperialDate" class="date"></div>
+      </footer>
+    </div>
+
+    <script src="./hub.js" type="module"></script>
+  </body>
+</html>

--- a/systems/taccog/USBHub/tools/stage2_dry_run_verify.py
+++ b/systems/taccog/USBHub/tools/stage2_dry_run_verify.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Stage 2 dry-run verifier.
+
+Validates the move plan, highlights immutable paths, and checks for collisions.
+"""
+from __future__ import annotations
+
+import json
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+PLAN_PATH = REPO_ROOT / "40k" / "USBHub" / "docs" / "stage2_move_plan.json"
+REPORT_PATH = REPO_ROOT / "40k" / "USBHub" / "docs" / "stage2_dry_run_report.txt"
+
+
+def relpath(path: Path) -> str:
+    return path.relative_to(REPO_ROOT).as_posix()
+
+
+def main() -> None:
+    if not PLAN_PATH.exists():
+        raise SystemExit(
+            "Missing stage2_move_plan.json. Run systems/taccog/USBHub/tools/stage2_move_plan.py first."
+        )
+
+    plan = json.loads(PLAN_PATH.read_text(encoding="utf-8"))
+    entries = plan.get("plans", [])
+
+    dest_counter = Counter(entry["destination"] for entry in entries)
+    collisions = [dest for dest, count in dest_counter.items() if count > 1]
+
+    immutable = [entry for entry in entries if entry.get("immutable")]
+    hub_entries = [entry for entry in entries if entry["source"].startswith("systems/taccog/USBHub/")]
+
+    timestamp = datetime.now(timezone.utc).isoformat()
+    lines = [
+        "Stage 2 Dry-Run Verification",
+        "============================",
+        f"Generated at: {timestamp}",
+        f"Plan source: {relpath(PLAN_PATH)}",
+        "",
+        f"Total entries: {len(entries)}",
+        f"Hub entries: {len(hub_entries)}",
+        f"Immutable flagged: {len(immutable)}",
+        f"Destination collisions: {len(collisions)}",
+        "",
+    ]
+
+    if collisions:
+        lines.append("Collisions (destinations with multiple sources):")
+        lines.extend(f"  - {dest} ({dest_counter[dest]} sources)" for dest in collisions[:200])
+        lines.append("")
+
+    lines.append("Immutable examples:")
+    if immutable:
+        lines.extend(f"  - {entry['source']} -> {entry['destination']}" for entry in immutable[:50])
+    else:
+        lines.append("  (none flagged)")
+
+    REPORT_PATH.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    print(f"Wrote {relpath(REPORT_PATH)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/systems/taccog/USBHub/tools/stage2_move_plan.py
+++ b/systems/taccog/USBHub/tools/stage2_move_plan.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Stage 2 move-map generator (planning only)."""
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+OUTPUT_JSON = REPO_ROOT / "40k" / "USBHub" / "docs" / "stage2_move_plan.json"
+OUTPUT_TXT = REPO_ROOT / "40k" / "USBHub" / "docs" / "stage2_move_plan.txt"
+
+IMMUTABLE_PARTS = {"worlds", ".git", "node_modules", "releases"}
+DEFAULT_EXCLUDES = {"reference", "imports"}
+
+
+@dataclass
+class MovePlan:
+    source: str
+    destination: str
+    rule: str
+    immutable: bool
+
+
+
+def relpath(path: Path) -> str:
+    return path.relative_to(REPO_ROOT).as_posix()
+
+
+def iter_files(root: Path) -> Iterable[Path]:
+    for path in root.rglob("*"):
+        if path.is_file():
+            yield path
+
+
+def is_excluded(rel: str, include_reference: bool, include_imports: bool) -> bool:
+    if not include_reference and rel.startswith("reference/"):
+        return True
+    if not include_imports and rel.startswith("imports/"):
+        return True
+    return False
+
+
+def is_immutable(rel: str) -> bool:
+    parts = set(rel.split("/"))
+    return bool(parts & IMMUTABLE_PARTS)
+
+
+def map_destination(rel: str) -> tuple[str, str]:
+    if rel.startswith("systems/taccog/USBHub/data/"):
+        return rel.replace("systems/taccog/USBHub/data/", "40k/data/hub/"), "hub-data-to-40k-data"
+    if rel.startswith("systems/taccog/USBHub/"):
+        return rel.replace("systems/taccog/USBHub/", "40k/USBHub/"), "hub-programs-to-40k"
+    if rel.startswith("40k/"):
+        return rel, "already-in-40k"
+    return f"40k/legacy/{rel}", "legacy-catchall"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate a Stage 2 move plan without executing it.")
+    parser.add_argument("--root", type=Path, default=REPO_ROOT)
+    parser.add_argument("--include-reference", action="store_true")
+    parser.add_argument("--include-imports", action="store_true")
+    args = parser.parse_args()
+
+    root = args.root.resolve()
+    include_reference = args.include_reference
+    include_imports = args.include_imports
+
+    plans: list[MovePlan] = []
+    for file in iter_files(root):
+        rel = relpath(file)
+        if is_excluded(rel, include_reference=include_reference, include_imports=include_imports):
+            continue
+        dest, rule = map_destination(rel)
+        plans.append(MovePlan(source=rel, destination=dest, rule=rule, immutable=is_immutable(rel)))
+
+    timestamp = datetime.now(timezone.utc).isoformat()
+    OUTPUT_JSON.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "generated_at": timestamp,
+        "root": relpath(root),
+        "include_reference": include_reference,
+        "include_imports": include_imports,
+        "immutables": sorted(IMMUTABLE_PARTS),
+        "plans": [plan.__dict__ for plan in plans],
+        "notes": [
+            "This file is planning-only. No moves are performed.",
+            "Review immutable entries (worlds, releases, node_modules) before Stage 2.",
+        ],
+    }
+    OUTPUT_JSON.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+    by_rule: dict[str, int] = {}
+    immutable_count = 0
+    for plan in plans:
+        by_rule[plan.rule] = by_rule.get(plan.rule, 0) + 1
+        immutable_count += int(plan.immutable)
+
+    lines = [
+        "Stage 2 Move Plan (Planning Only)",
+        "================================",
+        f"Generated at: {timestamp}",
+        f"Include /reference: {include_reference}",
+        f"Include /imports: {include_imports}",
+        "",
+        "Counts by rule:",
+    ]
+    lines.extend(f"  - {rule}: {count}" for rule, count in sorted(by_rule.items()))
+    lines.extend(
+        [
+            "",
+            f"Immutable entries flagged: {immutable_count}",
+            "",
+            f"JSON output: {relpath(OUTPUT_JSON)}",
+        ]
+    )
+    OUTPUT_TXT.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    print(f"Wrote {relpath(OUTPUT_JSON)}")
+    print(f"Wrote {relpath(OUTPUT_TXT)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/systems/taccog/USBHub/usbhub-library/docs/library_usage.txt
+++ b/systems/taccog/USBHub/usbhub-library/docs/library_usage.txt
@@ -1,0 +1,63 @@
+USBL Library — Stage 1.5 Usage Notes
+===================================
+
+Scope
+-----
+This program runs inside the USB40k hub iframe and respects the "none pre-loaded" rule.
+It is gated by Oculara access levels stored in localStorage:
+- USB_ACTIVE_USER
+- USB_ACTIVE_PROFILE
+- USB_ACCESS_LEVEL
+
+Data Roots
+----------
+Canonical library data root:
+  /systems/taccog/USBHub/data/library/
+
+Canonical metadata index:
+  /systems/taccog/USBHub/data/library/metadata.json
+
+Categories
+----------
+Required defaults:
+  reports, intel, books, transcriptions, other
+
+Stage 1.5 additions (for archive testing and variety):
+  dossiers, doctrine, schematics, communiques, xenology
+
+Filing Rules
+------------
+TXT and other plain-text materials:
+- Stored under /systems/taccog/USBHub/data/library/**
+- Each item is represented in metadata.json with type="txt"
+- Hashing for local text items uses sha256 when available (via tooling)
+
+PDF materials:
+- No PDF binaries should be committed.
+- Local PDF reference entries are allowed only when a PDF already exists locally.
+- Remote PDF links (e.g., Google Drive share URLs) are stored as type="link" with url.
+- The PDF Reader attempts iframe/embed rendering and always provides an "open in new tab" link.
+
+Intake Workflow (Operator)
+--------------------------
+1) Run the intake scan to produce candidate reports (default excludes /reference and /imports):
+
+   python systems/taccog/USBHub/usbhub-library/tools/library_intake_scan.py
+
+2) Review the outputs:
+
+   /systems/taccog/USBHub/data/library/intake_reports/intake_scan_report.json
+   /systems/taccog/USBHub/data/library/intake_reports/intake_scan_report.txt
+
+3) Approve moves by preparing an allowlist file (one path per line) and then run:
+
+   python systems/taccog/USBHub/usbhub-library/tools/library_intake_move.py \
+     --allowlist /path/to/allowlist.txt
+
+Backups are created automatically under:
+  /systems/taccog/USBHub/data/library/_backups/<timestamp>/
+
+Notes
+-----
+- Worlds and LevelDB sentinel files are treated as immutable by all tooling.
+- /reference and /imports are ignored by default; add --include-reference or --include-imports to opt in.

--- a/systems/taccog/USBHub/usbhub-library/index.html
+++ b/systems/taccog/USBHub/usbhub-library/index.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>USBL Library</title>
+    <link rel="stylesheet" href="./library.css" />
+  </head>
+  <body>
+    <main class="library" data-state="booting">
+      <header class="library__header">
+        <h1>Archivum Library</h1>
+        <p class="library__subtitle">Bootstrap checks must pass before the archive opens.</p>
+        <div class="library__status" id="libraryStatus" role="status" aria-live="polite"></div>
+      </header>
+
+      <section class="library__splash" id="splashPanel">
+        <h2>Integrity Checks</h2>
+        <ul id="checkList" class="checks"></ul>
+        <div class="splash__actions">
+          <button id="retryBootstrap" class="btn">Retry Bootstrap</button>
+        </div>
+      </section>
+
+      <section class="library__tabs" id="tabsPanel" hidden>
+        <nav class="tabs" role="tablist" aria-label="Library subprograms">
+          <button class="tab" data-tab="txt" role="tab">TXT Editor</button>
+          <button class="tab" data-tab="archive" role="tab">Archive Viewer</button>
+          <button class="tab" data-tab="transcription" role="tab">Transcription</button>
+          <button class="tab" data-tab="manager" role="tab">Archive Manager</button>
+          <button class="tab" data-tab="pdf" role="tab">PDF Reader</button>
+        </nav>
+        <section class="tabpanels">
+          <article class="tabpanel" data-panel="txt" role="tabpanel"></article>
+          <article class="tabpanel" data-panel="archive" role="tabpanel" hidden></article>
+          <article class="tabpanel" data-panel="transcription" role="tabpanel" hidden></article>
+          <article class="tabpanel" data-panel="manager" role="tabpanel" hidden></article>
+          <article class="tabpanel" data-panel="pdf" role="tabpanel" hidden></article>
+        </section>
+      </section>
+    </main>
+
+    <script src="./library.js" type="module"></script>
+  </body>
+</html>

--- a/systems/taccog/USBHub/usbhub-library/library.css
+++ b/systems/taccog/USBHub/usbhub-library/library.css
@@ -1,0 +1,213 @@
+:root {
+  --crt-bg: #040608;
+  --crt-panel: rgba(12, 22, 28, 0.94);
+  --crt-border: #34f5ff;
+  --crt-text: #e0fbff;
+  --crt-dim: #8ec5cf;
+  --crt-accent: #ff5c7a;
+  --crt-good: #7dffb6;
+  --crt-warn: #ffd479;
+  font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(circle at top, rgba(52, 245, 255, 0.09), transparent 60%), var(--crt-bg);
+  color: var(--crt-text);
+}
+
+.library {
+  padding: 1.4rem clamp(1rem, 2vw, 2.4rem) 2.4rem;
+  display: grid;
+  gap: 1rem;
+}
+
+.library__header,
+.library__splash,
+.library__tabs {
+  border: 1px solid rgba(52, 245, 255, 0.35);
+  background: var(--crt-panel);
+  padding: 1.2rem 1.35rem;
+  box-shadow: inset 0 0 40px rgba(52, 245, 255, 0.05);
+}
+
+.library__status {
+  margin-top: 0.6rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px dashed rgba(52, 245, 255, 0.5);
+  background: rgba(4, 14, 18, 0.85);
+  color: var(--crt-dim);
+}
+
+.checks {
+  margin: 0.8rem 0 1rem;
+  padding-left: 1.1rem;
+  display: grid;
+  gap: 0.4rem;
+}
+
+.checks li[data-tone="ok"] {
+  color: var(--crt-good);
+}
+
+.checks li[data-tone="warn"] {
+  color: var(--crt-warn);
+}
+
+.checks li[data-tone="err"] {
+  color: var(--crt-accent);
+}
+
+.splash__actions {
+  display: flex;
+  gap: 0.6rem;
+}
+
+.tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.tab {
+  padding: 0.55rem 0.9rem;
+  border: 1px solid rgba(52, 245, 255, 0.5);
+  background: rgba(8, 18, 24, 0.9);
+  color: var(--crt-text);
+  cursor: pointer;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.tab[aria-selected="true"] {
+  border-color: var(--crt-border);
+  box-shadow: 0 0 12px rgba(52, 245, 255, 0.25);
+}
+
+.tabpanel {
+  border-top: 1px dashed rgba(52, 245, 255, 0.3);
+  padding-top: 1rem;
+  display: grid;
+  gap: 0.9rem;
+}
+
+.btn {
+  padding: 0.6rem 1rem;
+  border: 1px solid rgba(52, 245, 255, 0.65);
+  background: linear-gradient(180deg, rgba(52, 245, 255, 0.2), rgba(52, 245, 255, 0.06));
+  color: var(--crt-text);
+  cursor: pointer;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.btn--ghost {
+  background: transparent;
+  border-style: dashed;
+}
+
+.panel-block {
+  border: 1px solid rgba(52, 245, 255, 0.25);
+  padding: 0.9rem;
+  background: rgba(3, 10, 14, 0.88);
+  display: grid;
+  gap: 0.6rem;
+}
+
+.panel-grid {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.panel-grid--cols {
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+label {
+  display: grid;
+  gap: 0.35rem;
+  font-size: 0.95rem;
+}
+
+input,
+select,
+textarea {
+  padding: 0.5rem 0.6rem;
+  border: 1px solid rgba(52, 245, 255, 0.5);
+  background: rgba(2, 8, 12, 0.92);
+  color: var(--crt-text);
+  font: inherit;
+}
+
+textarea {
+  min-height: 160px;
+  resize: vertical;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.95rem;
+}
+
+.table th,
+.table td {
+  border: 1px solid rgba(52, 245, 255, 0.25);
+  padding: 0.5rem 0.6rem;
+  text-align: left;
+  vertical-align: top;
+}
+
+.table th {
+  background: rgba(14, 28, 36, 0.95);
+}
+
+.pill-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
+.pill {
+  padding: 0.25rem 0.5rem;
+  border: 1px solid rgba(52, 245, 255, 0.4);
+  border-radius: 999px;
+  font-size: 0.85rem;
+  color: var(--crt-dim);
+}
+
+.viewer {
+  min-height: 55vh;
+  border: 1px solid rgba(52, 245, 255, 0.35);
+  background: rgba(1, 6, 8, 0.92);
+}
+
+.viewer iframe,
+.viewer embed {
+  width: 100%;
+  min-height: 55vh;
+  border: 0;
+  background: transparent;
+}
+
+.status {
+  font-weight: 600;
+}
+
+.status[data-tone="ok"] {
+  color: var(--crt-good);
+}
+
+.status[data-tone="warn"] {
+  color: var(--crt-warn);
+}
+
+.status[data-tone="err"] {
+  color: var(--crt-accent);
+}

--- a/systems/taccog/USBHub/usbhub-library/library.js
+++ b/systems/taccog/USBHub/usbhub-library/library.js
@@ -1,0 +1,593 @@
+const STORAGE_KEYS = {
+  user: "USB_ACTIVE_USER",
+  profile: "USB_ACTIVE_PROFILE",
+  access: "USB_ACCESS_LEVEL",
+};
+
+const ACCESS_ORDER = ["viewer", "operator", "admin", "root"];
+const ACCESS_RANK = new Map(ACCESS_ORDER.map((level, idx) => [level, idx]));
+
+const LIBRARY_ROOT = "../data/library";
+const METADATA_PATH = `${LIBRARY_ROOT}/metadata.json`;
+
+const REQUIRED_CATEGORIES = ["reports", "intel", "books", "transcriptions", "other"];
+const ADDITIONAL_CATEGORIES = ["dossiers", "doctrine", "schematics", "communiques", "xenology"];
+const ALL_CATEGORIES = [...REQUIRED_CATEGORIES, ...ADDITIONAL_CATEGORIES];
+
+const app = document.querySelector(".library");
+const libraryStatus = document.getElementById("libraryStatus");
+const splashPanel = document.getElementById("splashPanel");
+const tabsPanel = document.getElementById("tabsPanel");
+const checkList = document.getElementById("checkList");
+const retryBootstrap = document.getElementById("retryBootstrap");
+
+const tabButtons = Array.from(document.querySelectorAll(".tab"));
+const tabPanels = new Map(
+  Array.from(document.querySelectorAll(".tabpanel")).map((panel) => [panel.dataset.panel, panel]),
+);
+
+let metadata = null;
+let metadataDirty = false;
+
+function setStatus(message, tone = "ok") {
+  libraryStatus.textContent = message;
+  libraryStatus.dataset.tone = tone;
+}
+
+function accessRank() {
+  const level = localStorage.getItem(STORAGE_KEYS.access) ?? "viewer";
+  return ACCESS_RANK.get(level) ?? 0;
+}
+
+function ensureLocalStorageDefaults() {
+  if (!localStorage.getItem(STORAGE_KEYS.user)) localStorage.setItem(STORAGE_KEYS.user, "guest");
+  if (!localStorage.getItem(STORAGE_KEYS.profile)) localStorage.setItem(STORAGE_KEYS.profile, "guest");
+  if (!localStorage.getItem(STORAGE_KEYS.access)) localStorage.setItem(STORAGE_KEYS.access, "viewer");
+}
+
+function addCheck(message, tone) {
+  const li = document.createElement("li");
+  li.textContent = message;
+  li.dataset.tone = tone;
+  checkList.appendChild(li);
+}
+
+async function loadMetadata() {
+  const resp = await fetch(METADATA_PATH, { cache: "no-store" });
+  if (!resp.ok) throw new Error(`metadata.json ${resp.status}`);
+  metadata = await resp.json();
+  metadata.items = Array.isArray(metadata.items) ? metadata.items : [];
+  return metadata;
+}
+
+function metadataStats() {
+  const counts = metadata.items.reduce(
+    (acc, item) => {
+      acc.total += 1;
+      acc.byType[item.type] = (acc.byType[item.type] ?? 0) + 1;
+      acc.byCategory[item.category] = (acc.byCategory[item.category] ?? 0) + 1;
+      return acc;
+    },
+    { total: 0, byType: {}, byCategory: {} },
+  );
+  return counts;
+}
+
+function isoNow() {
+  return new Date().toISOString();
+}
+
+function slugify(value) {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/(^-|-$)/g, "")
+    .slice(0, 64);
+}
+
+function nextId(prefix = "lib") {
+  const base = `${prefix}-${slugify(localStorage.getItem(STORAGE_KEYS.user) ?? "guest")}`;
+  const suffix = Math.random().toString(36).slice(2, 8);
+  return `${base}-${suffix}`;
+}
+
+function markDirty() {
+  metadataDirty = true;
+  setStatus("Metadata updated locally. Use Export Metadata to persist changes.", "warn");
+  renderArchiveViewer();
+  renderArchiveManager();
+  renderPdfReader();
+}
+
+function exportMetadata() {
+  const blob = new Blob([JSON.stringify(metadata, null, 2)], { type: "application/json" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = "metadata.json";
+  a.click();
+  URL.revokeObjectURL(url);
+  setStatus("Exported metadata.json. Merge it with the canonical file via tooling.", "ok");
+}
+
+function archiveTableRows(items) {
+  if (!items.length) {
+    return "<tr><td colspan=6>No items match the current filters.</td></tr>";
+  }
+  return items
+    .map(
+      (item) => `
+      <tr>
+        <td>${item.title}</td>
+        <td>${item.type}</td>
+        <td>${item.category}</td>
+        <td>${item.status}</td>
+        <td>${(item.tags ?? []).map((tag) => `<span class="pill">${tag}</span>`).join(" ")}</td>
+        <td>${item.path ?? item.url ?? ""}</td>
+      </tr>
+    `,
+    )
+    .join("");
+}
+
+function wireTabButtons() {
+  tabButtons.forEach((btn, idx) => {
+    btn.setAttribute("aria-selected", idx === 0 ? "true" : "false");
+    btn.addEventListener("click", () => activateTab(btn.dataset.tab));
+  });
+}
+
+function activateTab(tabId) {
+  tabButtons.forEach((btn) => {
+    btn.setAttribute("aria-selected", btn.dataset.tab === tabId ? "true" : "false");
+  });
+  tabPanels.forEach((panel, id) => {
+    panel.hidden = id !== tabId;
+  });
+}
+
+function renderTxtEditor() {
+  const panel = tabPanels.get("txt");
+  panel.innerHTML = `
+    <section class="panel-block">
+      <h3>TXT Editor</h3>
+      <p>Open a cataloged TXT item to view or stage edits. Persist changes using the intake tooling.</p>
+      <div class="panel-grid panel-grid--cols">
+        <label>
+          Library TXT items
+          <select id="txtItemSelect"></select>
+        </label>
+        <div class="panel-grid">
+          <button class="btn" id="txtLoadBtn">Load TXT</button>
+          <button class="btn btn--ghost" id="txtExportBtn">Export Edited TXT</button>
+        </div>
+      </div>
+      <label>
+        Contents
+        <textarea id="txtEditor" placeholder="Select a TXT item to load..."></textarea>
+      </label>
+      <div class="status" id="txtStatus" data-tone="warn">No TXT loaded.</div>
+    </section>
+  `;
+
+  const txtItems = metadata.items.filter((item) => item.type === "txt" && item.path);
+  const select = panel.querySelector("#txtItemSelect");
+  select.innerHTML = txtItems
+    .map((item) => `<option value="${item.id}">${item.title}</option>`)
+    .join("");
+
+  const txtEditor = panel.querySelector("#txtEditor");
+  const txtStatus = panel.querySelector("#txtStatus");
+
+  panel.querySelector("#txtLoadBtn").addEventListener("click", async () => {
+    const selected = txtItems.find((item) => item.id === select.value);
+    if (!selected) {
+      txtStatus.textContent = "Select a TXT item first.";
+      txtStatus.dataset.tone = "warn";
+      return;
+    }
+    try {
+      const resp = await fetch(`..${selected.path.replace("/systems/taccog/USBHub", "")}`, { cache: "no-store" });
+      if (!resp.ok) throw new Error(`TXT fetch ${resp.status}`);
+      txtEditor.value = await resp.text();
+      txtStatus.textContent = `Loaded ${selected.title}.`;
+      txtStatus.dataset.tone = "ok";
+    } catch (err) {
+      console.warn(err);
+      txtStatus.textContent = "Unable to load TXT. Check the path or run intake tooling.";
+      txtStatus.dataset.tone = "err";
+    }
+  });
+
+  panel.querySelector("#txtExportBtn").addEventListener("click", () => {
+    const blob = new Blob([txtEditor.value], { type: "text/plain" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "library-edit.txt";
+    a.click();
+    URL.revokeObjectURL(url);
+    txtStatus.textContent = "Exported edited TXT. Merge using tooling.";
+    txtStatus.dataset.tone = "ok";
+  });
+}
+
+function renderArchiveViewer() {
+  const panel = tabPanels.get("archive");
+  const stats = metadataStats();
+  panel.innerHTML = `
+    <section class="panel-block">
+      <h3>Archive Viewer</h3>
+      <p>Browse catalog entries without moving files. Intake scripts handle safe relocation.</p>
+      <div class="panel-grid panel-grid--cols">
+        <div>
+          <strong>Total items:</strong> ${stats.total}
+        </div>
+        <div>
+          <strong>By type:</strong> ${Object.entries(stats.byType)
+            .map(([type, count]) => `${type}:${count}`)
+            .join(" | ") || "none"}
+        </div>
+      </div>
+      <div class="panel-grid panel-grid--cols">
+        <label>
+          Filter by category
+          <select id="archiveCategoryFilter">
+            <option value="">All categories</option>
+            ${ALL_CATEGORIES.map((category) => `<option value="${category}">${category}</option>`).join("")}
+          </select>
+        </label>
+        <label>
+          Filter by status
+          <select id="archiveStatusFilter">
+            <option value="">All statuses</option>
+            ${["active", "archived", "quarantined"].map((status) => `<option value="${status}">${status}</option>`).join("")}
+          </select>
+        </label>
+      </div>
+      <table class="table" id="archiveTable">
+        <thead>
+          <tr>
+            <th>Title</th>
+            <th>Type</th>
+            <th>Category</th>
+            <th>Status</th>
+            <th>Tags</th>
+            <th>Path / URL</th>
+          </tr>
+        </thead>
+        <tbody></tbody>
+      </table>
+    </section>
+  `;
+
+  const tbody = panel.querySelector("tbody");
+  const categoryFilter = panel.querySelector("#archiveCategoryFilter");
+  const statusFilter = panel.querySelector("#archiveStatusFilter");
+
+  const applyFilters = () => {
+    const filtered = metadata.items.filter((item) => {
+      if (categoryFilter.value && item.category !== categoryFilter.value) return false;
+      if (statusFilter.value && item.status !== statusFilter.value) return false;
+      return true;
+    });
+    tbody.innerHTML = archiveTableRows(filtered);
+  };
+
+  categoryFilter.addEventListener("change", applyFilters);
+  statusFilter.addEventListener("change", applyFilters);
+  applyFilters();
+}
+
+function renderTranscription() {
+  const panel = tabPanels.get("transcription");
+  panel.innerHTML = `
+    <section class="panel-block">
+      <h3>Transcription</h3>
+      <p>Stage transcription notes here, then file them through Archive Manager.</p>
+      <label>
+        Transcription draft
+        <textarea id="transcriptionDraft" placeholder="Paste or write transcription notes..."></textarea>
+      </label>
+      <div class="panel-grid panel-grid--cols">
+        <button class="btn" id="transcriptionExport">Export Draft</button>
+        <div class="status" id="transcriptionStatus" data-tone="warn">Draft not exported.</div>
+      </div>
+    </section>
+  `;
+
+  const draft = panel.querySelector("#transcriptionDraft");
+  const status = panel.querySelector("#transcriptionStatus");
+
+  panel.querySelector("#transcriptionExport").addEventListener("click", () => {
+    const blob = new Blob([draft.value], { type: "text/plain" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "transcription.txt";
+    a.click();
+    URL.revokeObjectURL(url);
+    status.textContent = "Draft exported. File it via Archive Manager tooling.";
+    status.dataset.tone = "ok";
+  });
+}
+
+function renderArchiveManager() {
+  const panel = tabPanels.get("manager");
+  const stats = metadataStats();
+  panel.innerHTML = `
+    <section class="panel-block">
+      <h3>Archive Manager</h3>
+      <p>Manage metadata entries. Local changes can be exported and merged via scripts.</p>
+      <div class="panel-grid panel-grid--cols">
+        <div><strong>Total:</strong> ${stats.total}</div>
+        <div><strong>Dirty state:</strong> ${metadataDirty ? "Yes" : "No"}</div>
+      </div>
+      <div class="panel-grid panel-grid--cols">
+        <button class="btn" id="exportMetadataBtn">Export Metadata</button>
+        <button class="btn btn--ghost" id="refreshMetadataBtn">Reload Metadata</button>
+      </div>
+    </section>
+
+    <section class="panel-block">
+      <h4>Add TXT Entry (Reference)</h4>
+      <form id="addTxtForm" class="panel-grid panel-grid--cols">
+        <label>
+          Title
+          <input name="title" required />
+        </label>
+        <label>
+          Category
+          <select name="category">
+            ${ALL_CATEGORIES.map((category) => `<option value="${category}">${category}</option>`).join("")}
+          </select>
+        </label>
+        <label>
+          Local path
+          <input name="path" placeholder="/systems/taccog/USBHub/data/library/reports/example.txt" required />
+        </label>
+        <label>
+          Tags (comma separated)
+          <input name="tags" placeholder="intel,session-01" />
+        </label>
+        <label class="panel-grid" style="grid-column: 1 / -1">
+          Notes
+          <textarea name="notes" placeholder="Source, summary, intake notes..."></textarea>
+        </label>
+        <div>
+          <button class="btn" type="submit">Add TXT Entry</button>
+        </div>
+      </form>
+    </section>
+
+    <section class="panel-block">
+      <h4>Add PDF or Link Entry</h4>
+      <form id="addPdfForm" class="panel-grid panel-grid--cols">
+        <label>
+          Title
+          <input name="title" required />
+        </label>
+        <label>
+          Entry type
+          <select name="type">
+            <option value="pdf">Local PDF reference</option>
+            <option value="link">Remote PDF link</option>
+          </select>
+        </label>
+        <label>
+          Category
+          <select name="category">
+            ${ALL_CATEGORIES.map((category) => `<option value="${category}">${category}</option>`).join("")}
+          </select>
+        </label>
+        <label>
+          Path or URL
+          <input name="pathOrUrl" placeholder="/path/to/file.pdf OR https://drive.google.com/..." required />
+        </label>
+        <label>
+          Tags (comma separated)
+          <input name="tags" placeholder="pdf,reference" />
+        </label>
+        <label class="panel-grid" style="grid-column: 1 / -1">
+          Notes
+          <textarea name="notes" placeholder="Embedding notes, access restrictions, etc."></textarea>
+        </label>
+        <div>
+          <button class="btn" type="submit">Add PDF/Link Entry</button>
+        </div>
+      </form>
+    </section>
+  `;
+
+  panel.querySelector("#exportMetadataBtn").addEventListener("click", exportMetadata);
+  panel.querySelector("#refreshMetadataBtn").addEventListener("click", () => bootstrap());
+
+  panel.querySelector("#addTxtForm").addEventListener("submit", (event) => {
+    event.preventDefault();
+    if (accessRank() < ACCESS_RANK.get("operator")) {
+      setStatus("Operator access is required to modify metadata.", "err");
+      return;
+    }
+    const formData = new FormData(event.currentTarget);
+    const item = {
+      id: nextId("txt"),
+      title: String(formData.get("title") ?? "Untitled"),
+      type: "txt",
+      category: String(formData.get("category") ?? "other"),
+      path: String(formData.get("path") ?? ""),
+      tags: String(formData.get("tags") ?? "")
+        .split(",")
+        .map((tag) => tag.trim())
+        .filter(Boolean),
+      created_at: isoNow(),
+      updated_at: isoNow(),
+      source: "manual",
+      notes: String(formData.get("notes") ?? ""),
+      hash: null,
+      status: "active",
+    };
+    metadata.items.unshift(item);
+    markDirty();
+    event.currentTarget.reset();
+  });
+
+  panel.querySelector("#addPdfForm").addEventListener("submit", (event) => {
+    event.preventDefault();
+    if (accessRank() < ACCESS_RANK.get("operator")) {
+      setStatus("Operator access is required to modify metadata.", "err");
+      return;
+    }
+    const formData = new FormData(event.currentTarget);
+    const type = String(formData.get("type") ?? "pdf");
+    const pathOrUrl = String(formData.get("pathOrUrl") ?? "");
+    const item = {
+      id: nextId(type),
+      title: String(formData.get("title") ?? "Untitled"),
+      type,
+      category: String(formData.get("category") ?? "other"),
+      tags: String(formData.get("tags") ?? "")
+        .split(",")
+        .map((tag) => tag.trim())
+        .filter(Boolean),
+      created_at: isoNow(),
+      updated_at: isoNow(),
+      source: "manual",
+      notes: String(formData.get("notes") ?? ""),
+      hash: null,
+      status: "active",
+    };
+    if (type === "link") {
+      item.url = pathOrUrl;
+      item.path = null;
+    } else {
+      item.path = pathOrUrl;
+      item.url = null;
+    }
+    metadata.items.unshift(item);
+    markDirty();
+    event.currentTarget.reset();
+  });
+}
+
+function pdfCandidates() {
+  return metadata.items.filter((item) => item.type === "pdf" || item.type === "link");
+}
+
+function renderPdfReader() {
+  const panel = tabPanels.get("pdf");
+  const candidates = pdfCandidates();
+  panel.innerHTML = `
+    <section class="panel-block">
+      <h3>PDF Reader</h3>
+      <p>Local PDF references render via embed/iframe. Remote links attempt iframe embedding and always provide a safe open-in-new-tab option.</p>
+      <div class="panel-grid panel-grid--cols">
+        <label>
+          PDF entries
+          <select id="pdfSelect">
+            ${candidates.map((item) => `<option value="${item.id}">${item.title} (${item.type})</option>`).join("")}
+          </select>
+        </label>
+        <div class="panel-grid">
+          <button class="btn" id="pdfLoadBtn">Load PDF</button>
+          <a class="btn btn--ghost" id="pdfOpenLink" target="_blank" rel="noopener noreferrer">Open in new tab</a>
+        </div>
+      </div>
+      <div class="viewer" id="pdfViewer"></div>
+      <div class="status" id="pdfStatus" data-tone="warn">No PDF loaded.</div>
+    </section>
+  `;
+
+  const select = panel.querySelector("#pdfSelect");
+  const viewer = panel.querySelector("#pdfViewer");
+  const status = panel.querySelector("#pdfStatus");
+  const openLink = panel.querySelector("#pdfOpenLink");
+
+  const load = () => {
+    const item = candidates.find((entry) => entry.id === select.value);
+    if (!item) {
+      status.textContent = "No PDF entries available.";
+      status.dataset.tone = "warn";
+      viewer.innerHTML = "";
+      openLink.removeAttribute("href");
+      return;
+    }
+    const target = item.type === "link" ? item.url : item.path;
+    if (!target) {
+      status.textContent = "Selected entry has no path or URL.";
+      status.dataset.tone = "err";
+      return;
+    }
+    openLink.href = target;
+
+    const embedTarget = item.type === "link" ? target : `..${target.replace("/systems/taccog/USBHub", "")}`;
+    viewer.innerHTML = `<iframe src="${embedTarget}" title="${item.title}"></iframe>`;
+    status.textContent = `Loaded ${item.title}. If the embed fails, use Open in new tab.`;
+    status.dataset.tone = "ok";
+  };
+
+  panel.querySelector("#pdfLoadBtn").addEventListener("click", load);
+  load();
+}
+
+async function bootstrap() {
+  ensureLocalStorageDefaults();
+  checkList.innerHTML = "";
+  setStatus("Running library bootstrap checks...", "warn");
+
+  const checks = [];
+
+  try {
+    addCheck("LocalStorage keys verified.", "ok");
+    if (accessRank() < ACCESS_RANK.get("viewer")) {
+      throw new Error("Access level missing.");
+    }
+
+    await loadMetadata();
+    checks.push({ message: "metadata.json loaded.", tone: "ok" });
+
+    const missingCategories = ALL_CATEGORIES.filter((category) => !metadata.categories?.includes(category));
+    if (missingCategories.length) {
+      checks.push({
+        message: `metadata.json missing categories: ${missingCategories.join(", ")}. Intake tooling can patch this safely.`,
+        tone: "warn",
+      });
+    } else {
+      checks.push({ message: "All required categories present.", tone: "ok" });
+    }
+
+    const intakeReportPath = `${LIBRARY_ROOT}/intake_reports/intake_scan_report.json`;
+    const intakeResp = await fetch(intakeReportPath, { cache: "no-store" });
+    checks.push({
+      message: intakeResp.ok
+        ? "Latest intake scan report detected."
+        : "No intake scan report detected yet (run library_intake_scan.py).",
+      tone: intakeResp.ok ? "ok" : "warn",
+    });
+
+    checks.forEach((check) => addCheck(check.message, check.tone));
+
+    splashPanel.hidden = true;
+    tabsPanel.hidden = false;
+    app.dataset.state = "ready";
+
+    wireTabButtons();
+    renderTxtEditor();
+    renderArchiveViewer();
+    renderTranscription();
+    renderArchiveManager();
+    renderPdfReader();
+
+    setStatus("Library online. Tabs unlocked.", "ok");
+  } catch (err) {
+    console.warn(err);
+    addCheck(`Bootstrap failure: ${err.message}`, "err");
+    splashPanel.hidden = false;
+    tabsPanel.hidden = true;
+    app.dataset.state = "error";
+    setStatus("Library bootstrap failed. See integrity checks.", "err");
+  }
+}
+
+retryBootstrap.addEventListener("click", bootstrap);
+
+bootstrap();

--- a/systems/taccog/USBHub/usbhub-library/tools/library_intake_move.py
+++ b/systems/taccog/USBHub/usbhub-library/tools/library_intake_move.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""Stage 1.5 library intake mover.
+
+Moves only approved safe text candidates into the library root, always creating
+backups first and updating metadata.json.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import shutil
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable
+
+REPO_ROOT = Path(__file__).resolve().parents[5]
+LIBRARY_ROOT = REPO_ROOT / "systems" / "taccog" / "USBHub" / "data" / "library"
+REPORT_ROOT = LIBRARY_ROOT / "intake_reports"
+METADATA_PATH = LIBRARY_ROOT / "metadata.json"
+
+PROTECTED_PREFIXES = (
+    Path("worlds"),
+    Path("releases"),
+    Path("systems/taccog/USBHub/usbhub-library"),
+    Path("systems/taccog/USBHub/data/library"),
+)
+
+CATEGORY_DEFAULT = "other"
+CATEGORY_BY_EXT = {
+    ".log": "reports",
+    ".md": "reports",
+    ".txt": "reports",
+    ".rtf": "transcriptions",
+}
+
+
+@dataclass
+class MoveResult:
+    source: str
+    backup: str
+    destination: str
+    category: str
+    hash_b64: str
+
+
+
+def relpath(path: Path) -> str:
+    return path.relative_to(REPO_ROOT).as_posix()
+
+
+def sha256_b64(path: Path) -> str:
+    digest = hashlib.sha256(path.read_bytes()).digest()
+    return digest.hex()
+
+
+def load_allowlist(path: Path) -> list[Path]:
+    entries: list[Path] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        entries.append((REPO_ROOT / line).resolve())
+    return entries
+
+
+def load_scan_report() -> dict:
+    report_path = REPORT_ROOT / "intake_scan_report.json"
+    if not report_path.exists():
+        raise SystemExit(
+            "Missing intake scan report. Run library_intake_scan.py before moving files."
+        )
+    return json.loads(report_path.read_text(encoding="utf-8"))
+
+
+def safe_candidates_from_report(report: dict) -> set[str]:
+    return {
+        candidate["path"]
+        for candidate in report.get("text_candidates", [])
+        if candidate.get("safe_to_move")
+    }
+
+
+def is_protected(path: Path) -> bool:
+    rel = path.relative_to(REPO_ROOT)
+    for prefix in PROTECTED_PREFIXES:
+        if rel == prefix or str(rel).startswith(f"{prefix.as_posix()}/"):
+            return True
+    return False
+
+
+def ensure_metadata() -> dict:
+    if METADATA_PATH.exists():
+        return json.loads(METADATA_PATH.read_text(encoding="utf-8"))
+    return {"version": "0.01a", "categories": [], "items": []}
+
+
+def pick_category(path: Path) -> str:
+    return CATEGORY_BY_EXT.get(path.suffix.lower(), CATEGORY_DEFAULT)
+
+
+def unique_destination(dest_dir: Path, filename: str) -> Path:
+    candidate = dest_dir / filename
+    if not candidate.exists():
+        return candidate
+    stem = candidate.stem
+    suffix = candidate.suffix
+    counter = 2
+    while True:
+        candidate = dest_dir / f"{stem}-{counter}{suffix}"
+        if not candidate.exists():
+            return candidate
+        counter += 1
+
+
+def backup_root() -> Path:
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    root = LIBRARY_ROOT / "_backups" / timestamp
+    root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
+def update_metadata(metadata: dict, result: MoveResult) -> None:
+    now = datetime.now(timezone.utc).isoformat()
+    metadata.setdefault("items", [])
+    metadata.setdefault("categories", [])
+    if result.category not in metadata["categories"]:
+        metadata["categories"].append(result.category)
+
+    metadata["items"].insert(
+        0,
+        {
+            "id": f"txt-{Path(result.destination).stem}",
+            "title": Path(result.destination).name,
+            "type": "txt",
+            "category": result.category,
+            "path": f"/{result.destination}",
+            "tags": ["intake", "auto-moved"],
+            "created_at": now,
+            "updated_at": now,
+            "source": "intake-script",
+            "notes": f"Moved from /{result.source} with backup /{result.backup}.",
+            "hash": result.hash_b64,
+            "status": "active",
+        },
+    )
+
+
+def write_reports(results: Iterable[MoveResult]) -> None:
+    results = list(results)
+    REPORT_ROOT.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.now(timezone.utc).isoformat()
+    json_path = REPORT_ROOT / "intake_move_report.json"
+    txt_path = REPORT_ROOT / "intake_move_report.txt"
+
+    payload = {
+        "version": "0.01a",
+        "generated_at": timestamp,
+        "moves": [result.__dict__ for result in results],
+        "count": len(results),
+    }
+    json_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+    lines = [
+        "USBL Library Intake Move Report",
+        "===============================",
+        f"Generated at: {timestamp}",
+        f"Moves: {len(results)}",
+        "",
+    ]
+    if results:
+        lines.extend(
+            f"- /{result.source} -> /{result.destination} (backup: /{result.backup})" for result in results
+        )
+    else:
+        lines.append("(no files moved)")
+
+    txt_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    print(f"Wrote {json_path.relative_to(REPO_ROOT)}")
+    print(f"Wrote {txt_path.relative_to(REPO_ROOT)}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Move approved library intake candidates.")
+    parser.add_argument(
+        "--allowlist",
+        type=Path,
+        required=True,
+        help="Path to allowlist file (one repo-relative path per line).",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report what would happen without moving files.",
+    )
+    args = parser.parse_args()
+
+    report = load_scan_report()
+    safe_candidates = safe_candidates_from_report(report)
+
+    allowlist_path = args.allowlist.resolve()
+    if not allowlist_path.exists():
+        raise SystemExit(f"Allowlist not found: {allowlist_path}")
+
+    allowlisted = load_allowlist(allowlist_path)
+    metadata = ensure_metadata()
+    backup_dir = backup_root()
+
+    results: list[MoveResult] = []
+
+    for source in allowlisted:
+        if not source.exists():
+            print(f"Skipping missing file: {source}")
+            continue
+        rel_source = relpath(source)
+        if rel_source not in safe_candidates:
+            print(f"Skipping non-safe candidate (per scan report): {rel_source}")
+            continue
+        if is_protected(source):
+            print(f"Skipping protected path: {rel_source}")
+            continue
+
+        category = pick_category(source)
+        dest_dir = LIBRARY_ROOT / category
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        destination = unique_destination(dest_dir, source.name)
+
+        backup_target = backup_dir / rel_source.replace("/", "__")
+        backup_target.parent.mkdir(parents=True, exist_ok=True)
+
+        if args.dry_run:
+            print(f"DRY RUN: would backup {rel_source} -> {relpath(backup_target)}")
+            print(f"DRY RUN: would move {rel_source} -> {relpath(destination)}")
+            continue
+
+        shutil.copy2(source, backup_target)
+        shutil.move(source, destination)
+        file_hash = sha256_b64(destination)
+
+        result = MoveResult(
+            source=rel_source,
+            backup=relpath(backup_target),
+            destination=relpath(destination),
+            category=category,
+            hash_b64=file_hash,
+        )
+        results.append(result)
+        update_metadata(metadata, result)
+
+    if not args.dry_run:
+        METADATA_PATH.write_text(json.dumps(metadata, indent=2), encoding="utf-8")
+        write_reports(results)
+    else:
+        print("Dry run complete; no files moved.")
+
+
+if __name__ == "__main__":
+    main()

--- a/systems/taccog/USBHub/usbhub-library/tools/library_intake_scan.py
+++ b/systems/taccog/USBHub/usbhub-library/tools/library_intake_scan.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""Stage 1.5 library intake scanner.
+
+Scans for text-like documents and PDFs, determines conservative usage, and emits
+reports without moving anything.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass, asdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable
+
+REPO_ROOT = Path(__file__).resolve().parents[5]
+LIBRARY_ROOT = REPO_ROOT / "systems" / "taccog" / "USBHub" / "data" / "library"
+REPORT_ROOT = LIBRARY_ROOT / "intake_reports"
+
+TEXT_EXTENSIONS = {".txt", ".md", ".log", ".rtf"}
+REFERENCE_EXTENSIONS = {
+    ".html",
+    ".htm",
+    ".js",
+    ".mjs",
+    ".cjs",
+    ".ts",
+    ".jsx",
+    ".tsx",
+    ".json",
+    ".css",
+    ".less",
+    ".py",
+    ".yml",
+    ".yaml",
+}
+PDF_EXTENSIONS = {".pdf"}
+
+# Immutable and/or high-risk zones.
+PROTECTED_PARTS = {
+    ".git",
+    "node_modules",
+    "releases",
+    "worlds",
+    "build",
+    "dist",
+    "systems/taccog/USBHub/usbhub-library",
+    "systems/taccog/USBHub/data/library",
+}
+
+DEFAULT_EXCLUDES = {"reference", "imports"}
+
+
+def relpath(path: Path) -> str:
+    return path.relative_to(REPO_ROOT).as_posix()
+
+
+def is_protected(path: Path) -> bool:
+    rel = relpath(path)
+    parts = set(rel.split("/"))
+    if parts & {"worlds"}:
+        return True
+    for protected in PROTECTED_PARTS:
+        if rel == protected or rel.startswith(f"{protected}/"):
+            return True
+    return False
+
+
+def should_skip(path: Path, exclude_reference: bool, exclude_imports: bool) -> bool:
+    rel = relpath(path)
+    if exclude_reference and rel.startswith("reference/"):
+        return True
+    if exclude_imports and rel.startswith("imports/"):
+        return True
+    return False
+
+
+def iter_files(root: Path) -> Iterable[Path]:
+    for path in root.rglob("*"):
+        if path.is_file():
+            yield path
+
+
+@dataclass
+class Candidate:
+    path: str
+    ext: str
+    size: int
+    used_reference_hits: int
+    used_reference_examples: list[str]
+    protected: bool
+    safe_to_move: bool
+    reason: str
+
+
+
+def build_reference_corpus(files: Iterable[Path]) -> list[tuple[str, str]]:
+    corpus: list[tuple[str, str]] = []
+    for file in files:
+        if file.suffix.lower() not in REFERENCE_EXTENSIONS:
+            continue
+        try:
+            corpus.append((relpath(file), file.read_text(encoding="utf-8", errors="ignore")))
+        except OSError:
+            continue
+    return corpus
+
+
+
+def find_usage_hits(candidate: Path, corpus: list[tuple[str, str]]) -> tuple[int, list[str]]:
+    rel = relpath(candidate)
+    name = candidate.name
+    hits: list[str] = []
+    for ref_path, content in corpus:
+        if rel in content or name in content:
+            hits.append(ref_path)
+            if len(hits) >= 10:
+                break
+    return len(hits), hits[:5]
+
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Scan for library intake candidates.")
+    parser.add_argument("--root", type=Path, default=REPO_ROOT, help="Repository root to scan.")
+    parser.add_argument(
+        "--include-reference",
+        action="store_true",
+        help="Include /reference in the scan (ignored by default).",
+    )
+    parser.add_argument(
+        "--include-imports",
+        action="store_true",
+        help="Include /imports in the scan (ignored by default).",
+    )
+    args = parser.parse_args()
+
+    root = args.root.resolve()
+    exclude_reference = not args.include_reference
+    exclude_imports = not args.include_imports
+
+    REPORT_ROOT.mkdir(parents=True, exist_ok=True)
+
+    all_files = [
+        path
+        for path in iter_files(root)
+        if not should_skip(path, exclude_reference=exclude_reference, exclude_imports=exclude_imports)
+    ]
+
+    corpus = build_reference_corpus(all_files)
+
+    text_candidates: list[Candidate] = []
+    pdf_candidates: list[Candidate] = []
+
+    for file in all_files:
+        ext = file.suffix.lower()
+        if ext not in TEXT_EXTENSIONS | PDF_EXTENSIONS:
+            continue
+
+        protected = is_protected(file)
+        hits, examples = find_usage_hits(file, corpus)
+
+        if protected:
+            safe_to_move = False
+            reason = "protected-zone"
+        elif hits > 0:
+            safe_to_move = False
+            reason = "referenced-by-program"
+        else:
+            safe_to_move = ext in TEXT_EXTENSIONS
+            reason = "unreferenced-text" if safe_to_move else "pdf-reference-only"
+
+        candidate = Candidate(
+            path=relpath(file),
+            ext=ext,
+            size=file.stat().st_size,
+            used_reference_hits=hits,
+            used_reference_examples=examples,
+            protected=protected,
+            safe_to_move=safe_to_move,
+            reason=reason,
+        )
+
+        if ext in TEXT_EXTENSIONS:
+            text_candidates.append(candidate)
+        else:
+            pdf_candidates.append(candidate)
+
+    timestamp = datetime.now(timezone.utc).isoformat()
+    manifest_txt = root / "manifest.txt"
+
+    report = {
+        "version": "0.01a",
+        "generated_at": timestamp,
+        "scan_root": relpath(root),
+        "defaults": {
+            "exclude_reference": exclude_reference,
+            "exclude_imports": exclude_imports,
+        },
+        "manifest_txt_present": manifest_txt.exists(),
+        "text_candidates": [asdict(candidate) for candidate in sorted(text_candidates, key=lambda c: c.path)],
+        "pdf_candidates": [asdict(candidate) for candidate in sorted(pdf_candidates, key=lambda c: c.path)],
+        "summary": {
+            "text_total": len(text_candidates),
+            "text_safe_to_move": sum(1 for c in text_candidates if c.safe_to_move),
+            "pdf_total": len(pdf_candidates),
+            "pdf_reference_only": len(pdf_candidates),
+        },
+        "notes": [
+            "This scan is conservative: any filename hit in code marks a file as referenced.",
+            "PDFs are indexed only; binaries must not be committed.",
+        ],
+    }
+
+    json_path = REPORT_ROOT / "intake_scan_report.json"
+    txt_path = REPORT_ROOT / "intake_scan_report.txt"
+
+    json_path.write_text(json.dumps(report, indent=2), encoding="utf-8")
+
+    safe_moves = [c for c in text_candidates if c.safe_to_move]
+    blocked = [c for c in text_candidates if not c.safe_to_move]
+
+    lines = [
+        "USBL Library Intake Scan Report",
+        "===============================",
+        f"Generated at: {timestamp}",
+        f"Scan root: {relpath(root)}",
+        "",
+        "Defaults:",
+        f"  exclude /reference: {exclude_reference}",
+        f"  exclude /imports: {exclude_imports}",
+        f"  manifest.txt present: {manifest_txt.exists()}",
+        "",
+        "Summary:",
+        f"  Text candidates: {len(text_candidates)}",
+        f"  Safe-to-move text candidates: {len(safe_moves)}",
+        f"  PDF candidates (reference-only): {len(pdf_candidates)}",
+        "",
+        "Safe-to-move text candidates:",
+    ]
+
+    if safe_moves:
+        lines.extend(f"  - {c.path} ({c.reason})" for c in safe_moves[:200])
+    else:
+        lines.append("  (none detected)")
+
+    lines.extend(["", "Blocked or referenced text candidates:"])
+    if blocked:
+        lines.extend(f"  - {c.path} ({c.reason})" for c in blocked[:200])
+    else:
+        lines.append("  (none)")
+
+    lines.extend(["", "PDF references:"])
+    if pdf_candidates:
+        lines.extend(f"  - {c.path} ({c.reason})" for c in pdf_candidates[:200])
+    else:
+        lines.append("  (none detected)")
+
+    txt_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    print(f"Wrote {json_path.relative_to(root)}")
+    print(f"Wrote {txt_path.relative_to(root)}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation

- Provide a conservative Stage 1.5 implementation that seeds a localhost-only USBHub and a gated library program without performing the full /40k restructure.
- Consolidate Oculara-based auth and localStorage-based access keys to gate program access during Stage 1.5.
- Offer safe, review-first intake tooling to discover and prepare text/PDF candidates for the library while protecting immutable zones (worlds, releases, .git, node_modules).
- Produce Stage 2 planning/dry-run scripts and audit documents so an operator can review a proposed /40k move map before any moves are executed.

### Description

- Added a minimal USBHub UI and controller under `systems/taccog/USBHub/` that preserves the iframe "none pre-loaded" contract and uses the localStorage keys `USB_ACTIVE_USER`, `USB_ACTIVE_PROFILE`, and `USB_ACCESS_LEVEL` for gating (`index.html`, `hub.css`, `hub.js`).
- Implemented canonical Oculara registries at `systems/taccog/USBHub/data/oclara/` using salted PBKDF2 password hashes and a profiles registry to seed access levels and profiles (`users.json`, `profiles.json`).
- Implemented the `usbhub-library` program with a bootstrap splash, tabbed subprograms (TXT Editor, Archive Viewer, Transcription, Archive Manager, PDF Reader), a metadata schema, and non-destructive UI features (`usbhub-library/index.html`, `library.css`, `library.js`, `data/library/metadata.json`).
- Added intake tooling and safeguards: `library_intake_scan.py` (conservative discovery, defaults exclude `/reference` and `/imports`, marks protected/immutable files) and `library_intake_move.py` (moves only allowlisted safe text files, creates backups under `_backups`, updates metadata.json); plus Stage 2 planning tools `stage2_move_plan.py` and `stage2_dry_run_verify.py` and operator docs under `40k/USBHub/docs/` and `systems/taccog/USBHub/usbhub-library/docs/`.

### Testing

- Ran `python systems/taccog/USBHub/usbhub-library/tools/library_intake_scan.py --root systems/taccog/USBHub` and it completed successfully and wrote `systems/taccog/USBHub/data/library/intake_reports/intake_scan_report.json` and `.txt`.
- Ran `python systems/taccog/USBHub/tools/stage2_move_plan.py --root systems/taccog/USBHub` and it completed successfully and wrote `40k/USBHub/docs/stage2_move_plan.json`/`.txt`.
- Ran `python systems/taccog/USBHub/tools/stage2_dry_run_verify.py` and it completed successfully and wrote `40k/USBHub/docs/stage2_dry_run_report.txt`.
- All executed scripts returned success (no failures) during validation runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974fde424188327abeefef085e2dc2e)